### PR TITLE
Spec v0: draft structure + canonical AST schema + fixture

### DIFF
--- a/README.org
+++ b/README.org
@@ -13,6 +13,10 @@ As originally described in https://avi.press/posts/2024-01-15-standalone-org.htm
 - Work towards a formal specification of the Org format.
 - Support a thriving plug-in ecosystem that leverages more popular development environments.
 
+** Spec
+
+- v0 (draft): [[./spec/v0/SPEC.md]]
+
 ** Contributing and Project Status
 
 This project is in the very early stages of development. If you're interested in contributing, please reach out. Especially if you are someone getting into open source for the first time -- I'd be open to mentoring the right person who has the potential to get this project off the ground with a little help.

--- a/spec/v0/SPEC.md
+++ b/spec/v0/SPEC.md
@@ -1,0 +1,62 @@
+# Org2 Specification v0 (Draft)
+
+This is the initial, intentionally-scoped Org2 specification.
+
+The primary goal of v0 is to define a **lossless, round-trippable parse** of Org-like documents into a **canonical AST**.
+
+## Scope
+
+**In scope (normative)**
+- Input text → canonical AST
+- Canonical AST schema and invariants
+- Normative fixtures: `.org` input → `.json` AST output
+
+**Out of scope (explicit, non-normative for v0)**
+- TODO workflow semantics
+- Agenda behavior
+- Clocking
+- Property inheritance
+- Export rules
+- Editor behavior / UI
+
+## Specification Model
+
+Org2 is specified in layers:
+
+### Layer 1: Syntax → Canonical AST (normative)
+
+A compliant implementation MUST:
+- Parse a document into the **canonical AST** described by `canonical-ast.schema.json`.
+- Preserve enough information to **round-trip** to the original bytes (modulo a future, explicitly-defined normalization layer).
+
+The authoritative definition of correctness is:
+- The **canonical AST schema**: `canonical-ast.schema.json`
+- The **normative fixtures** in `tests/`
+
+A grammar (Tree-sitter, PEG, etc.) is recommended, but is not itself authoritative; it is an implementation detail as long as it produces the canonical AST.
+
+### Layer 2: Semantic modules (future, normative, scoped)
+
+Semantics are defined as independent modules that operate on the canonical AST.
+
+Examples (not yet specified):
+- `org2-sem-todo`
+- `org2-sem-time`
+- `org2-sem-properties`
+- `org2-sem-links`
+
+An implementation may support any subset of modules, but MUST be explicit about which modules (and which versions) it supports.
+
+## Versioning
+
+- This directory is `spec/v0/`.
+- Additive, backwards-compatible changes MAY be made within v0 as patch revisions.
+- Breaking changes MUST be done in a new spec version directory (e.g. `spec/v1/`).
+
+## Normative fixtures
+
+Fixtures live in `tests/`:
+- `NNNN-*.org` is the input
+- `NNNN-*.json` is the canonical AST output
+
+Implementations SHOULD run these fixtures as golden tests.

--- a/spec/v0/canonical-ast.schema.json
+++ b/spec/v0/canonical-ast.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://avi.press/org2/spec/v0/canonical-ast.schema.json",
+  "title": "Org2 Canonical AST (v0)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["type", "version", "children"],
+  "properties": {
+    "type": {
+      "const": "Document"
+    },
+    "version": {
+      "type": "string",
+      "const": "0"
+    },
+    "children": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Node" }
+    }
+  },
+  "$defs": {
+    "Node": {
+      "oneOf": [
+        { "$ref": "#/$defs/Headline" },
+        { "$ref": "#/$defs/Paragraph" },
+        { "$ref": "#/$defs/Text" }
+      ]
+    },
+    "Headline": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "level", "title", "children"],
+      "properties": {
+        "type": { "const": "Headline" },
+        "level": { "type": "integer", "minimum": 1 },
+        "title": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Inline" }
+        },
+        "children": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Node" }
+        }
+      }
+    },
+    "Paragraph": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "children"],
+      "properties": {
+        "type": { "const": "Paragraph" },
+        "children": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Inline" }
+        }
+      }
+    },
+    "Text": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "value"],
+      "properties": {
+        "type": { "const": "Text" },
+        "value": { "type": "string" }
+      }
+    },
+    "Inline": {
+      "oneOf": [
+        { "$ref": "#/$defs/Text" }
+      ]
+    }
+  }
+}

--- a/spec/v0/tests/0001-basic-headline.json
+++ b/spec/v0/tests/0001-basic-headline.json
@@ -1,0 +1,21 @@
+{
+  "type": "Document",
+  "version": "0",
+  "children": [
+    {
+      "type": "Headline",
+      "level": 1,
+      "title": [
+        { "type": "Text", "value": "Hello" }
+      ],
+      "children": [
+        {
+          "type": "Paragraph",
+          "children": [
+            { "type": "Text", "value": "This is a paragraph." }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/v0/tests/0001-basic-headline.org
+++ b/spec/v0/tests/0001-basic-headline.org
@@ -1,0 +1,3 @@
+* Hello
+
+This is a paragraph.


### PR DESCRIPTION
Closes #1.

Implements a first draft of the proposed layered Org2 spec:
- Layer 1 (normative): canonical AST + fixtures
- Layer 2 (future): semantic modules (outlined only)

Added:
- `spec/v0/SPEC.md`: spec structure + scope
- `spec/v0/canonical-ast.schema.json`: initial canonical AST JSON schema (Document/Headline/Paragraph/Text)
- `spec/v0/tests/0001-basic-headline.{org,json}`: first golden fixture
- `README.org`: links to spec v0

Notes/decisions:
- Fixtures are treated as normative artifacts, even though there’s no runner in-repo yet.
- Schema is intentionally minimal to unblock contributors; future fixtures should drive expansion.

TODO:
- Add a fixture runner (language TBD) that validates JSON against schema and compares expected outputs.
- Expand fixtures for drawers, blocks, lists, timestamps, links, etc.
- Decide on a grammar vehicle (tree-sitter vs PEG) and host it in-repo.

---
AI-assisted: This PR was generated with AI assistance from openai-codex/gpt-5.2.
