### PR TITLE
grammar: add tree-sitter scaffold

### DIFF
--- a/tree-sitter-org2/README.md
+++ b/tree-sitter-org2/README.md
@@ -1,0 +1,23 @@
+# tree-sitter-org2
+
+A minimal Tree-sitter grammar scaffold for **Org2**.
+
+## Status
+
+This grammar is intentionally small and **non-normative**. It exists to support early editor experimentation (highlighting, folding, incremental parsing).
+
+The canonical definition of Org2 remains the **spec + fixtures** (and any future canonical AST format). If there is any mismatch between this grammar and the spec/fixtures, the spec/fixtures win.
+
+## What it parses (currently)
+
+- Headlines: leading `*` stars, a single space, then title text
+- Paragraph/text lines
+
+## Development
+
+```sh
+npm install
+npm test
+```
+
+`npm test` runs `tree-sitter test` using the corpus files in `test/corpus/`.

--- a/tree-sitter-org2/grammar.js
+++ b/tree-sitter-org2/grammar.js
@@ -1,0 +1,39 @@
+// Intentionally minimal, non-normative grammar scaffold.
+// Org2's canonical meaning is defined by its AST + fixtures/spec,
+// not by this Tree-sitter grammar.
+
+module.exports = grammar({
+  name: 'org2',
+
+  extras: $ => [/[ \t]/],
+
+  rules: {
+    source_file: $ => repeat($._element),
+
+    _element: $ => choice($.headline, $.paragraph, $.blank_line),
+
+    blank_line: _ => /\n+/,
+
+    headline: $ => seq(
+      field('stars', $.stars),
+      ' ',
+      field('title', $.title),
+      optional(/\n+/)
+    ),
+
+    // One or more '*' characters.
+    stars: _ => token(/\*+/),
+
+    // Headline title text up to end-of-line.
+    title: _ => token(/[^\n]+/),
+
+    // One or more non-headline lines (doesn't start with "* ").
+    paragraph: $ => seq(
+      field('line', $.text),
+      repeat(seq(/\n/, field('line', $.text))),
+      optional(/\n+/)
+    ),
+
+    text: _ => token(/(?!\*+\s)[^\n]+/)
+  }
+});

--- a/tree-sitter-org2/package.json
+++ b/tree-sitter-org2/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "tree-sitter-org2",
+  "version": "0.0.1",
+  "description": "Tree-sitter grammar scaffold for Org2 (non-normative)",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/avi/org2"
+  },
+  "main": "index.js",
+  "files": [
+    "grammar.js",
+    "queries/",
+    "test/"
+  ],
+  "scripts": {
+    "test": "tree-sitter test"
+  },
+  "devDependencies": {
+    "tree-sitter-cli": "^0.22.6"
+  }
+}

--- a/tree-sitter-org2/test/corpus/basic.txt
+++ b/tree-sitter-org2/test/corpus/basic.txt
@@ -1,0 +1,29 @@
+=== Headlines
+
+* Hello world
+
+---
+
+(source_file
+  (headline stars: (stars) title: (title)))
+
+=== Multiple Headlines
+
+* One
+* Two
+
+---
+
+(source_file
+  (headline stars: (stars) title: (title))
+  (headline stars: (stars) title: (title)))
+
+=== Paragraph
+
+This is a paragraph.
+Second line.
+
+---
+
+(source_file
+  (paragraph line: (text) line: (text)))


### PR DESCRIPTION
This PR adds a minimal Tree-sitter grammar scaffold for Org2.

Notes:
- Grammar is intentionally minimal and non-normative.
- Canonical meaning remains the spec + fixtures.

This PR was generated with AI assistance from openai-codex/gpt-5.2
