### PR TITLE
Spec + fixtures: headline nesting

### DIFF
--- a/spec/v0/SPEC.md
+++ b/spec/v0/SPEC.md
@@ -60,3 +60,34 @@ Fixtures live in `tests/`:
 - `NNNN-*.json` is the canonical AST output
 
 Implementations SHOULD run these fixtures as golden tests.
+
+## Headlines (subheadings)
+
+### Headline syntax
+
+A **headline line** is a line that matches:
+
+- One or more `*` characters at the start of the line.
+- Exactly one space after the `*` run.
+- A non-empty title string after that space.
+
+A headline line produces a `Headline` node with:
+
+- `level`: the number of `*` characters.
+- `title`: an array of inline nodes (v0: a single `Text` node containing the title string).
+
+### Headline nesting
+
+Headlines form a tree via their `children` arrays.
+
+When a headline of level `L` is parsed:
+
+- It becomes a child of the nearest preceding headline whose level is **strictly less than** `L`.
+- If there is no preceding headline with level `< L`, the headline becomes a direct child of the `Document`.
+- All subsequent non-headline nodes (e.g. paragraphs) attach to the most recent headline (at any level) until a new headline changes the current container.
+
+### Level skips
+
+Level skips are allowed and deterministic.
+
+For example, a level-3 headline (`***`) immediately after a level-1 headline (`*`) becomes a child of that level-1 headline; no implicit level-2 headline nodes are created.

--- a/spec/v0/tests/0002-nested-headlines.json
+++ b/spec/v0/tests/0002-nested-headlines.json
@@ -1,0 +1,41 @@
+{
+  "type": "Document",
+  "version": "0",
+  "children": [
+    {
+      "type": "Headline",
+      "level": 1,
+      "title": [{ "type": "Text", "value": "A" }],
+      "children": [
+        {
+          "type": "Headline",
+          "level": 2,
+          "title": [{ "type": "Text", "value": "B" }],
+          "children": [
+            {
+              "type": "Paragraph",
+              "children": [{ "type": "Text", "value": "B paragraph." }]
+            }
+          ]
+        },
+        {
+          "type": "Headline",
+          "level": 2,
+          "title": [{ "type": "Text", "value": "C" }],
+          "children": []
+        }
+      ]
+    },
+    {
+      "type": "Headline",
+      "level": 1,
+      "title": [{ "type": "Text", "value": "D" }],
+      "children": [
+        {
+          "type": "Paragraph",
+          "children": [{ "type": "Text", "value": "D paragraph." }]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/v0/tests/0002-nested-headlines.org
+++ b/spec/v0/tests/0002-nested-headlines.org
@@ -1,0 +1,10 @@
+* A
+** B
+
+B paragraph.
+
+** C
+
+* D
+
+D paragraph.

--- a/spec/v0/tests/0003-headline-level-skip.json
+++ b/spec/v0/tests/0003-headline-level-skip.json
@@ -1,0 +1,35 @@
+{
+  "type": "Document",
+  "version": "0",
+  "children": [
+    {
+      "type": "Headline",
+      "level": 1,
+      "title": [{ "type": "Text", "value": "A" }],
+      "children": [
+        {
+          "type": "Headline",
+          "level": 3,
+          "title": [{ "type": "Text", "value": "C" }],
+          "children": [
+            {
+              "type": "Paragraph",
+              "children": [{ "type": "Text", "value": "C paragraph." }]
+            }
+          ]
+        },
+        {
+          "type": "Headline",
+          "level": 2,
+          "title": [{ "type": "Text", "value": "B" }],
+          "children": [
+            {
+              "type": "Paragraph",
+              "children": [{ "type": "Text", "value": "B paragraph." }]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/v0/tests/0003-headline-level-skip.org
+++ b/spec/v0/tests/0003-headline-level-skip.org
@@ -1,0 +1,8 @@
+* A
+*** C
+
+C paragraph.
+
+** B
+
+B paragraph.


### PR DESCRIPTION
Implements #8.

- Defines headline nesting/subheading rules in `spec/v0/SPEC.md`.
- Adds normative fixtures for nested headlines and level-skip behavior.
- Parser already matches the specified nesting behavior; `npm test` passes.

This PR was generated with AI assistance from openai-codex/gpt-5.2