### PR TITLE
feat(v0): TODO keyword + tags

### DIFF
--- a/spec/v0/SPEC.md
+++ b/spec/v0/SPEC.md
@@ -12,7 +12,7 @@ The primary goal of v0 is to define a **lossless, round-trippable parse** of Org
 - Normative fixtures: `.org` input → `.json` AST output
 
 **Out of scope (explicit, non-normative for v0)**
-- TODO workflow semantics
+- TODO workflow semantics (syntax may be parsed, semantics are out of scope)
 - Agenda behavior
 - Clocking
 - Property inheritance
@@ -75,6 +75,27 @@ A headline line produces a `Headline` node with:
 
 - `level`: the number of `*` characters.
 - `title`: an array of inline nodes (v0: a single `Text` node containing the title string).
+
+### TODO keywords (syntax only)
+
+A headline title MAY begin with a TODO keyword.
+
+In v0, the only supported TODO keyword is `TODO`.
+
+Example:
+- `* TODO Fix bug` produces a `Headline` with `todo: "TODO"` and `title: "Fix bug"`.
+
+TODO workflow semantics are out of scope for v0.
+
+### Tags (syntax only)
+
+A headline title MAY end with a tag group:
+- tag group syntax is `:tag1:tag2:`
+- it MUST appear at the end of the headline
+- tags MUST NOT contain whitespace
+
+Example:
+- `* Plan release :ops:launch:` produces `tags: ["ops", "launch"]` and `title: "Plan release"`.
 
 ### Headline nesting
 

--- a/spec/v0/canonical-ast.schema.json
+++ b/spec/v0/canonical-ast.schema.json
@@ -36,6 +36,11 @@
       "properties": {
         "type": { "const": "Headline" },
         "level": { "type": "integer", "minimum": 1 },
+        "todo": { "type": "string" },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
         "title": {
           "type": "array",
           "items": { "$ref": "#/$defs/Inline" }

--- a/spec/v0/tests/0005-headline-todo.json
+++ b/spec/v0/tests/0005-headline-todo.json
@@ -1,0 +1,13 @@
+{
+  "type": "Document",
+  "version": "0",
+  "children": [
+    {
+      "type": "Headline",
+      "level": 1,
+      "todo": "TODO",
+      "title": [{ "type": "Text", "value": "Write parser" }],
+      "children": []
+    }
+  ]
+}

--- a/spec/v0/tests/0005-headline-todo.org
+++ b/spec/v0/tests/0005-headline-todo.org
@@ -1,0 +1,1 @@
+* TODO Write parser

--- a/spec/v0/tests/0006-headline-tags.json
+++ b/spec/v0/tests/0006-headline-tags.json
@@ -1,0 +1,13 @@
+{
+  "type": "Document",
+  "version": "0",
+  "children": [
+    {
+      "type": "Headline",
+      "level": 1,
+      "tags": ["ops", "launch"],
+      "title": [{ "type": "Text", "value": "Plan release" }],
+      "children": []
+    }
+  ]
+}

--- a/spec/v0/tests/0006-headline-tags.org
+++ b/spec/v0/tests/0006-headline-tags.org
@@ -1,0 +1,1 @@
+* Plan release :ops:launch:

--- a/spec/v0/tests/0007-headline-todo-tags.json
+++ b/spec/v0/tests/0007-headline-todo-tags.json
@@ -1,0 +1,14 @@
+{
+  "type": "Document",
+  "version": "0",
+  "children": [
+    {
+      "type": "Headline",
+      "level": 1,
+      "todo": "TODO",
+      "tags": ["infra"],
+      "title": [{ "type": "Text", "value": "Fix CI" }],
+      "children": []
+    }
+  ]
+}

--- a/spec/v0/tests/0007-headline-todo-tags.org
+++ b/spec/v0/tests/0007-headline-todo-tags.org
@@ -1,0 +1,1 @@
+* TODO Fix CI :infra:

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -22,6 +22,8 @@ export type ListNode = {
 export type HeadlineNode = {
   type: "Headline";
   level: number;
+  todo?: string;
+  tags?: string[];
   title: InlineNode[];
   children: Node[];
 };

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -32,7 +32,10 @@ function isBlank(line: string): boolean {
   return line.trim().length === 0;
 }
 
-function parseHeadline(line: string, lineNumber: number): { level: number; title: string } {
+function parseHeadline(
+  line: string,
+  lineNumber: number,
+): { level: number; title: string; todo?: string; tags?: string[] } {
   const match = /^(\*+)(\s+)(.*)$/.exec(line);
   if (!match) {
     fail(makeError("Invalid headline; expected one or more '*' followed by a space", lineNumber, 1));
@@ -40,17 +43,43 @@ function parseHeadline(line: string, lineNumber: number): { level: number; title
 
   const stars = match[1];
   const ws = match[2];
-  const title = match[3];
+  const raw = match[3];
 
   if (ws !== " ") {
     fail(makeError("Invalid headline; only a single space is allowed after '*'", lineNumber, stars.length + 1));
   }
 
-  if (title.length === 0) {
+  if (raw.length === 0) {
     fail(makeError("Invalid headline; title cannot be empty", lineNumber, stars.length + 2));
   }
 
-  return { level: stars.length, title };
+  let todo;
+  let tags;
+  let rest = raw;
+
+  {
+    const parts = rest.split(/\s+/);
+    const last = parts[parts.length - 1] ?? "";
+
+    if (last.startsWith(":") && /^:(?:[^\s:]+:)+$/.test(last)) {
+      const parsed = last.split(":").filter((t) => t.length > 0);
+      if (parsed.length > 0) {
+        tags = parsed;
+        rest = rest.slice(0, rest.length - last.length).trimEnd();
+      }
+    }
+  }
+
+  if (rest.startsWith("TODO ")) {
+    todo = "TODO";
+    rest = rest.slice("TODO ".length);
+  }
+
+  if (rest.length === 0) {
+    fail(makeError("Invalid headline; title cannot be empty", lineNumber, stars.length + 2));
+  }
+
+  return { level: stars.length, title: rest, todo, tags };
 }
 
 function getChildrenArray(node: DocumentNode | HeadlineNode): Node[] {
@@ -149,7 +178,7 @@ export function parseOrgToCanonicalAst(input: string): DocumentNode {
       flushParagraph();
       endList();
 
-      const { level, title } = parseHeadline(line, lineNumber);
+      const { level, title, todo, tags } = parseHeadline(line, lineNumber);
 
       while (headlineStack.length > 0 && headlineStack[headlineStack.length - 1].level >= level) {
         headlineStack.pop();
@@ -158,6 +187,8 @@ export function parseOrgToCanonicalAst(input: string): DocumentNode {
       const node: HeadlineNode = {
         type: "Headline",
         level,
+        ...(todo ? { todo } : {}),
+        ...(tags ? { tags } : {}),
         title: [text(title)],
         children: [],
       };


### PR DESCRIPTION
Closes #10.

Adds headline TODO keyword + tags to spec v0, schema, fixtures, and the TypeScript reference parser.

Supported syntax (v0):
- TODO keyword: `* TODO Title` (only `TODO` is recognized; semantics are out of scope)
- Tags: headline suffix `:tag1:tag2:` (must be at end of line; no whitespace inside)
- Both combined: `* TODO Title :tag:`

New fixtures:
- `0005-headline-todo`
- `0006-headline-tags`
- `0007-headline-todo-tags`

Implementation notes:
- `Headline` gains optional `todo?: string` and `tags?: string[]`.

AI disclaimer: This PR was generated with AI assistance from openai-codex/gpt-5.2
