### PR TITLE
Add minimal VS Code extension for Org2

### DIFF
--- a/editors/README.md
+++ b/editors/README.md
@@ -1,0 +1,3 @@
+# Editor integrations
+
+- `vscode-org2/`: VS Code language extension (MVP)

--- a/editors/vscode-org2/.vscodeignore
+++ b/editors/vscode-org2/.vscodeignore
@@ -1,0 +1,2 @@
+**/.gitignore
+**/.DS_Store

--- a/editors/vscode-org2/README.md
+++ b/editors/vscode-org2/README.md
@@ -1,0 +1,12 @@
+# Org2 (VS Code)
+
+Minimal VS Code language support for Org2.
+
+## Features
+
+- File association for `*.org2`
+- Basic syntax highlighting (headings, directives, blocks, drawers, lists, links)
+
+## Notes
+
+This is intentionally small and TextMate-based. The repo also contains a Tree-sitter grammar in `tree-sitter-org2/` for future richer editor integrations.

--- a/editors/vscode-org2/language-configuration.json
+++ b/editors/vscode-org2/language-configuration.json
@@ -1,0 +1,20 @@
+{
+  "comments": {},
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"", "notIn": ["string"] }
+  ],
+  "surroundingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"" }
+  ]
+}

--- a/editors/vscode-org2/package.json
+++ b/editors/vscode-org2/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "org2-vscode",
+  "displayName": "Org2",
+  "description": "Org2 language support (syntax highlighting)",
+  "version": "0.0.1",
+  "publisher": "org2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aviaviavi/org2"
+  },
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "contributes": {
+    "languages": [
+      {
+        "id": "org2",
+        "aliases": ["Org2", "org2"],
+        "extensions": [".org2"],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "org2",
+        "scopeName": "source.org2",
+        "path": "./syntaxes/org2.tmLanguage.json"
+      }
+    ]
+  }
+}

--- a/editors/vscode-org2/syntaxes/org2.tmLanguage.json
+++ b/editors/vscode-org2/syntaxes/org2.tmLanguage.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Org2",
+  "scopeName": "source.org2",
+  "patterns": [
+    { "include": "#directives" },
+    { "include": "#blocks" },
+    { "include": "#headlines" },
+    { "include": "#drawers" },
+    { "include": "#lists" },
+    { "include": "#checkboxes" },
+    { "include": "#links" }
+  ],
+  "repository": {
+    "directives": {
+      "patterns": [
+        {
+          "name": "keyword.other.directive.org2",
+          "match": "^(?:\\s*)#\\+[A-Za-z0-9_\\-]+(?::\\s+.*)?$"
+        }
+      ]
+    },
+    "blocks": {
+      "patterns": [
+        {
+          "name": "meta.block.org2",
+          "begin": "^(?:\\s*)#\\+begin_[A-Za-z0-9_\\-]+.*$",
+          "beginCaptures": {
+            "0": { "name": "keyword.other.block.begin.org2" }
+          },
+          "end": "^(?:\\s*)#\\+end_[A-Za-z0-9_\\-]+.*$",
+          "endCaptures": {
+            "0": { "name": "keyword.other.block.end.org2" }
+          },
+          "patterns": [
+            { "name": "text.plain.org2", "match": ".+" }
+          ]
+        }
+      ]
+    },
+    "headlines": {
+      "patterns": [
+        {
+          "name": "markup.heading.org2",
+          "match": "^(\\*+)\\s+(.+)$",
+          "captures": {
+            "1": { "name": "punctuation.definition.heading.org2" },
+            "2": { "name": "entity.name.section.org2" }
+          }
+        }
+      ]
+    },
+    "drawers": {
+      "patterns": [
+        {
+          "name": "meta.drawer.org2",
+          "begin": "^(?:\\s*):([A-Za-z0-9_\\-]+):\\s*$",
+          "beginCaptures": {
+            "0": { "name": "keyword.other.drawer.begin.org2" },
+            "1": { "name": "support.constant.drawer.name.org2" }
+          },
+          "end": "^(?:\\s*):END:\\s*$",
+          "endCaptures": {
+            "0": { "name": "keyword.other.drawer.end.org2" }
+          },
+          "patterns": [
+            {
+              "name": "meta.property.org2",
+              "match": "^(?:\\s*):([A-Za-z0-9_\\-]+):\\s*(.*)$",
+              "captures": {
+                "1": { "name": "variable.other.property.org2" },
+                "2": { "name": "string.unquoted.org2" }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "lists": {
+      "patterns": [
+        {
+          "name": "punctuation.definition.list.org2",
+          "match": "^(?:\\s*)(?:[-+]|\\d+[.)])(?=\\s)"
+        }
+      ]
+    },
+    "checkboxes": {
+      "patterns": [
+        {
+          "name": "constant.other.checkbox.org2",
+          "match": "\\[(?: |X|-)\\]"
+        }
+      ]
+    },
+    "links": {
+      "patterns": [
+        {
+          "name": "markup.underline.link.org2",
+          "match": "\\[\\[[^\\]]+\\](?:\\[[^\\]]*\\])?\\]"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds a small VS Code language extension for Org2 with:\n\n- File association for *.org2\n- Basic TextMate syntax highlighting\n- Language configuration (brackets/autoclosing)\n\nThis PR was generated with AI assistance from openai-codex/gpt-5.2.