### PR TITLE
Add property drawers (spec + schema + parser)

### DIFF
--- a/spec/v0/SPEC.md
+++ b/spec/v0/SPEC.md
@@ -112,3 +112,35 @@ When a headline of level `L` is parsed:
 Level skips are allowed and deterministic.
 
 For example, a level-3 headline (`***`) immediately after a level-1 headline (`*`) becomes a child of that level-1 headline; no implicit level-2 headline nodes are created.
+
+## Property drawers (syntax only)
+
+Property drawers are supported as a structural syntax element.
+
+Property inheritance and other property semantics are out of scope for v0.
+
+### Property drawer syntax
+
+A property drawer is a block consisting of:
+
+- A start line exactly equal to `:PROPERTIES:`
+- Zero or more property lines
+- An end line exactly equal to `:END:`
+
+Property drawers produce a `PropertyDrawer` node.
+
+### Property line syntax
+
+A property line MUST match:
+
+- A leading `:`
+- A non-empty key (no whitespace, no `:`)
+- A `:`
+- Optionally a single space
+- The value (possibly empty)
+
+Example:
+
+- `:ID: abc123` produces `{ key: "ID", value: "abc123" }`
+
+Property drawers may appear as children of `Headline` nodes (and implementations MAY also support them at document level).

--- a/spec/v0/canonical-ast.schema.json
+++ b/spec/v0/canonical-ast.schema.json
@@ -26,6 +26,7 @@
         { "$ref": "#/$defs/Paragraph" },
         { "$ref": "#/$defs/List" },
         { "$ref": "#/$defs/ListItem" },
+        { "$ref": "#/$defs/PropertyDrawer" },
         { "$ref": "#/$defs/Text" }
       ]
     },
@@ -86,6 +87,27 @@
           "type": "array",
           "items": { "$ref": "#/$defs/Node" }
         }
+      }
+    },
+    "PropertyDrawer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "properties"],
+      "properties": {
+        "type": { "const": "PropertyDrawer" },
+        "properties": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Property" }
+        }
+      }
+    },
+    "Property": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "value"],
+      "properties": {
+        "key": { "type": "string" },
+        "value": { "type": "string" }
       }
     },
     "Text": {

--- a/spec/v0/tests/0008-property-drawer.json
+++ b/spec/v0/tests/0008-property-drawer.json
@@ -1,0 +1,36 @@
+{
+  "type": "Document",
+  "version": "0",
+  "children": [
+    {
+      "type": "Headline",
+      "level": 1,
+      "title": [
+        {
+          "type": "Text",
+          "value": "With properties"
+        }
+      ],
+      "children": [
+        {
+          "type": "PropertyDrawer",
+          "properties": [
+            {
+              "key": "ID",
+              "value": "abc123"
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "children": [
+            {
+              "type": "Text",
+              "value": "Body text"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/v0/tests/0008-property-drawer.org
+++ b/spec/v0/tests/0008-property-drawer.org
@@ -1,0 +1,6 @@
+* With properties
+:PROPERTIES:
+:ID: abc123
+:END:
+
+Body text

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -8,6 +8,16 @@ export type ParagraphNode = {
   children: InlineNode[];
 };
 
+export type PropertyNode = {
+  key: string;
+  value: string;
+};
+
+export type PropertyDrawerNode = {
+  type: "PropertyDrawer";
+  properties: PropertyNode[];
+};
+
 export type ListItemNode = {
   type: "ListItem";
   children: Node[];
@@ -30,7 +40,7 @@ export type HeadlineNode = {
 
 export type InlineNode = TextNode;
 
-export type Node = HeadlineNode | ParagraphNode | ListNode | ListItemNode | TextNode;
+export type Node = HeadlineNode | ParagraphNode | ListNode | ListItemNode | PropertyDrawerNode | TextNode;
 
 export type DocumentNode = {
   type: "Document";

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,4 +1,13 @@
-import type { DocumentNode, HeadlineNode, ListItemNode, ListNode, Node, ParagraphNode, TextNode } from "./ast.js";
+import type {
+  DocumentNode,
+  HeadlineNode,
+  ListItemNode,
+  ListNode,
+  Node,
+  ParagraphNode,
+  PropertyDrawerNode,
+  TextNode,
+} from "./ast.js";
 
 export type ParseError = {
   message: string;
@@ -91,6 +100,54 @@ type ParsedListItem = {
   content: string;
 };
 
+type ParsePropertyDrawerResult = {
+  drawer: PropertyDrawerNode;
+  nextLineIndex: number;
+};
+
+function parsePropertyDrawer(lines: string[], startLineIndex: number): ParsePropertyDrawerResult {
+  const startLineNumber = startLineIndex + 1;
+
+  if (lines[startLineIndex] !== ":PROPERTIES:") {
+    fail(makeError("Invalid property drawer; expected :PROPERTIES:", startLineNumber, 1));
+  }
+
+  const properties: PropertyDrawerNode["properties"] = [];
+
+  for (let i = startLineIndex + 1; i < lines.length; i += 1) {
+    const lineNumber = i + 1;
+    const line = lines[i];
+
+    if (line === ":END:") {
+      return {
+        drawer: { type: "PropertyDrawer", properties },
+        nextLineIndex: i + 1,
+      };
+    }
+
+    if (isBlank(line)) {
+      fail(makeError("Invalid property drawer; blank lines are not allowed", lineNumber, 1));
+    }
+
+    const match = /^:([^:\s]+):(\s*)(.*)$/.exec(line);
+    if (!match) {
+      fail(makeError("Invalid property drawer line; expected :KEY: VALUE", lineNumber, 1));
+    }
+
+    const key = match[1];
+    const ws = match[2];
+    const rawValue = match[3];
+
+    if (ws !== " " && ws !== "") {
+      fail(makeError("Invalid property drawer line; only a single space is allowed after :KEY:", lineNumber, key.length + 3));
+    }
+
+    properties.push({ key, value: rawValue });
+  }
+
+  fail(makeError("Invalid property drawer; missing :END:", startLineNumber, 1));
+}
+
 function parseListItemLine(line: string): ParsedListItem | null {
   const unordered = /^([+-])(\s+)(.*)$/.exec(line);
   if (unordered) {
@@ -166,7 +223,7 @@ export function parseOrgToCanonicalAst(input: string): DocumentNode {
 
   const lines = input.split("\n");
 
-  for (let i = 0; i < lines.length; i += 1) {
+  for (let i = 0; i < lines.length; ) {
     const lineNumber = i + 1;
     const line = lines[i];
 
@@ -195,12 +252,24 @@ export function parseOrgToCanonicalAst(input: string): DocumentNode {
 
       getChildrenArray(currentContainer()).push(node);
       headlineStack.push(node);
+      i += 1;
+      continue;
+    }
+
+    if (line === ":PROPERTIES:") {
+      flushParagraph();
+      endList();
+
+      const { drawer, nextLineIndex } = parsePropertyDrawer(lines, i);
+      getChildrenArray(currentContainer()).push(drawer);
+      i = nextLineIndex;
       continue;
     }
 
     if (isBlank(line)) {
       flushParagraph();
       endList();
+      i += 1;
       continue;
     }
 
@@ -212,11 +281,13 @@ export function parseOrgToCanonicalAst(input: string): DocumentNode {
     if (listItem) {
       flushParagraph();
       addListItem(listItem.ordered, listItem.content);
+      i += 1;
       continue;
     }
 
     endList();
     paragraphLines.push(line);
+    i += 1;
   }
 
   flushParagraph();


### PR DESCRIPTION
Closes #11.

This PR adds a minimal, syntax-only representation of property drawers to the v0 spec, canonical AST schema, and reference parser, plus a fixture.

This PR was generated with AI assistance from openai-codex/gpt-5.2