### PR TITLE
Spec+schema+parser: SOURCE blocks

### DIFF
--- a/spec/v0/SPEC.md
+++ b/spec/v0/SPEC.md
@@ -144,3 +144,40 @@ Example:
 - `:ID: abc123` produces `{ key: "ID", value: "abc123" }`
 
 Property drawers may appear as children of `Headline` nodes (and implementations MAY also support them at document level).
+
+## SOURCE blocks (#+begin_src / #+end_src)
+
+Source blocks are supported as a structural syntax element.
+
+Executing source blocks and interpreting header args (babel semantics) are out of scope for v0.
+
+### SOURCE block syntax
+
+A source block is a block consisting of:
+
+- A begin line matching `#+begin_src` (case-insensitive), with optional indentation.
+- Zero or more body lines (treated as raw text).
+- An end line matching `#+end_src` (case-insensitive), with optional indentation.
+
+The parser MUST treat the body as raw text until it encounters an end marker line.
+
+### Lossless capture
+
+A `SrcBlock` node MUST capture enough information to reproduce the exact original bytes of:
+
+- The begin marker line (indentation, keyword spelling, and all bytes after the keyword).
+- The block body (all bytes between the end of the begin marker line and the start of the end marker line).
+- The end marker line (indentation, keyword spelling, and all bytes after the keyword).
+
+In v0, the canonical AST captures begin/end marker lines as:
+
+- `begin.indent`, `begin.keywordRaw`, `begin.afterKeywordRaw`
+- `end.indent`, `end.keywordRaw`, `end.afterKeywordRaw`
+
+### Unterminated blocks
+
+If a begin marker is not terminated by a matching end marker before end-of-file, the parser MUST emit a `SrcBlock` node with:
+
+- `terminated: false`
+- `end` omitted
+- `bodyRaw` containing all remaining bytes until end-of-file

--- a/spec/v0/canonical-ast.schema.json
+++ b/spec/v0/canonical-ast.schema.json
@@ -27,6 +27,7 @@
         { "$ref": "#/$defs/List" },
         { "$ref": "#/$defs/ListItem" },
         { "$ref": "#/$defs/PropertyDrawer" },
+        { "$ref": "#/$defs/SrcBlock" },
         { "$ref": "#/$defs/Text" }
       ]
     },
@@ -108,6 +109,42 @@
       "properties": {
         "key": { "type": "string" },
         "value": { "type": "string" }
+      }
+    },
+    "SrcBlock": {
+      "oneOf": [{ "$ref": "#/$defs/SrcBlockTerminated" }, { "$ref": "#/$defs/SrcBlockUnterminated" }]
+    },
+    "SrcBlockLine": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["indent", "keywordRaw", "afterKeywordRaw"],
+      "properties": {
+        "indent": { "type": "string" },
+        "keywordRaw": { "type": "string" },
+        "afterKeywordRaw": { "type": "string" }
+      }
+    },
+    "SrcBlockTerminated": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "terminated", "begin", "bodyRaw", "end"],
+      "properties": {
+        "type": { "const": "SrcBlock" },
+        "terminated": { "const": true },
+        "begin": { "$ref": "#/$defs/SrcBlockLine" },
+        "bodyRaw": { "type": "string" },
+        "end": { "$ref": "#/$defs/SrcBlockLine" }
+      }
+    },
+    "SrcBlockUnterminated": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "terminated", "begin", "bodyRaw"],
+      "properties": {
+        "type": { "const": "SrcBlock" },
+        "terminated": { "const": false },
+        "begin": { "$ref": "#/$defs/SrcBlockLine" },
+        "bodyRaw": { "type": "string" }
       }
     },
     "Text": {

--- a/spec/v0/tests/0009-src-block-basic.json
+++ b/spec/v0/tests/0009-src-block-basic.json
@@ -1,0 +1,21 @@
+{
+  "type": "Document",
+  "version": "0",
+  "children": [
+    {
+      "type": "SrcBlock",
+      "terminated": true,
+      "begin": {
+        "indent": "",
+        "keywordRaw": "begin_src",
+        "afterKeywordRaw": " python"
+      },
+      "bodyRaw": "print(\"hi\")",
+      "end": {
+        "indent": "",
+        "keywordRaw": "end_src",
+        "afterKeywordRaw": ""
+      }
+    }
+  ]
+}

--- a/spec/v0/tests/0009-src-block-basic.org
+++ b/spec/v0/tests/0009-src-block-basic.org
@@ -1,0 +1,3 @@
+#+begin_src python
+print("hi")
+#+end_src

--- a/spec/v0/tests/0010-src-block-header-args.json
+++ b/spec/v0/tests/0010-src-block-header-args.json
@@ -1,0 +1,21 @@
+{
+  "type": "Document",
+  "version": "0",
+  "children": [
+    {
+      "type": "SrcBlock",
+      "terminated": true,
+      "begin": {
+        "indent": "",
+        "keywordRaw": "begin_src",
+        "afterKeywordRaw": " sh :results output :foo bar"
+      },
+      "bodyRaw": "echo hi",
+      "end": {
+        "indent": "",
+        "keywordRaw": "end_src",
+        "afterKeywordRaw": ""
+      }
+    }
+  ]
+}

--- a/spec/v0/tests/0010-src-block-header-args.org
+++ b/spec/v0/tests/0010-src-block-header-args.org
@@ -1,0 +1,3 @@
+#+begin_src sh :results output :foo bar
+echo hi
+#+end_src

--- a/spec/v0/tests/0011-src-block-case-no-language.json
+++ b/spec/v0/tests/0011-src-block-case-no-language.json
@@ -1,0 +1,21 @@
+{
+  "type": "Document",
+  "version": "0",
+  "children": [
+    {
+      "type": "SrcBlock",
+      "terminated": true,
+      "begin": {
+        "indent": "",
+        "keywordRaw": "BEGIN_SRC",
+        "afterKeywordRaw": ""
+      },
+      "bodyRaw": "x",
+      "end": {
+        "indent": "",
+        "keywordRaw": "END_SRC",
+        "afterKeywordRaw": ""
+      }
+    }
+  ]
+}

--- a/spec/v0/tests/0011-src-block-case-no-language.org
+++ b/spec/v0/tests/0011-src-block-case-no-language.org
@@ -1,0 +1,3 @@
+#+BEGIN_SRC
+x
+#+END_SRC

--- a/spec/v0/tests/0012-src-block-in-list.json
+++ b/spec/v0/tests/0012-src-block-in-list.json
@@ -1,0 +1,41 @@
+{
+  "type": "Document",
+  "version": "0",
+  "children": [
+    {
+      "type": "List",
+      "ordered": false,
+      "items": [
+        {
+          "type": "ListItem",
+          "children": [
+            {
+              "type": "Paragraph",
+              "children": [
+                {
+                  "type": "Text",
+                  "value": "item"
+                }
+              ]
+            },
+            {
+              "type": "SrcBlock",
+              "terminated": true,
+              "begin": {
+                "indent": "  ",
+                "keywordRaw": "begin_src",
+                "afterKeywordRaw": " sh"
+              },
+              "bodyRaw": "  echo hi",
+              "end": {
+                "indent": "  ",
+                "keywordRaw": "end_src",
+                "afterKeywordRaw": ""
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/v0/tests/0012-src-block-in-list.org
+++ b/spec/v0/tests/0012-src-block-in-list.org
@@ -1,0 +1,4 @@
+- item
+  #+begin_src sh
+  echo hi
+  #+end_src

--- a/spec/v0/tests/0013-src-block-unterminated.json
+++ b/spec/v0/tests/0013-src-block-unterminated.json
@@ -1,0 +1,16 @@
+{
+  "type": "Document",
+  "version": "0",
+  "children": [
+    {
+      "type": "SrcBlock",
+      "terminated": false,
+      "begin": {
+        "indent": "",
+        "keywordRaw": "begin_src",
+        "afterKeywordRaw": ""
+      },
+      "bodyRaw": "hi"
+    }
+  ]
+}

--- a/spec/v0/tests/0013-src-block-unterminated.org
+++ b/spec/v0/tests/0013-src-block-unterminated.org
@@ -1,0 +1,2 @@
+#+begin_src
+hi

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -18,6 +18,20 @@ export type PropertyDrawerNode = {
   properties: PropertyNode[];
 };
 
+export type SrcBlockLine = {
+  indent: string;
+  keywordRaw: string;
+  afterKeywordRaw: string;
+};
+
+export type SrcBlockNode = {
+  type: "SrcBlock";
+  terminated: boolean;
+  begin: SrcBlockLine;
+  bodyRaw: string;
+  end?: SrcBlockLine;
+};
+
 export type ListItemNode = {
   type: "ListItem";
   children: Node[];
@@ -40,7 +54,14 @@ export type HeadlineNode = {
 
 export type InlineNode = TextNode;
 
-export type Node = HeadlineNode | ParagraphNode | ListNode | ListItemNode | PropertyDrawerNode | TextNode;
+export type Node =
+  | HeadlineNode
+  | ParagraphNode
+  | ListNode
+  | ListItemNode
+  | PropertyDrawerNode
+  | SrcBlockNode
+  | TextNode;
 
 export type DocumentNode = {
   type: "Document";

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -6,6 +6,8 @@ import type {
   Node,
   ParagraphNode,
   PropertyDrawerNode,
+  SrcBlockLine,
+  SrcBlockNode,
   TextNode,
 } from "./ast.js";
 
@@ -98,6 +100,7 @@ function getChildrenArray(node: DocumentNode | HeadlineNode): Node[] {
 type ParsedListItem = {
   ordered: boolean;
   content: string;
+  indentColumn: number;
 };
 
 type ParsePropertyDrawerResult = {
@@ -155,7 +158,7 @@ function parseListItemLine(line: string): ParsedListItem | null {
     if (ws !== " ") return null;
     const content = unordered[3];
     if (content.length === 0) return null;
-    return { ordered: false, content };
+    return { ordered: false, content, indentColumn: unordered[1].length + ws.length };
   }
 
   const ordered = /^(\d+)([.)])(\s+)(.*)$/.exec(line);
@@ -164,10 +167,81 @@ function parseListItemLine(line: string): ParsedListItem | null {
     if (ws !== " ") return null;
     const content = ordered[4];
     if (content.length === 0) return null;
-    return { ordered: true, content };
+    return {
+      ordered: true,
+      content,
+      indentColumn: ordered[1].length + ordered[2].length + ws.length,
+    };
   }
 
   return null;
+}
+
+type ParseSrcBlockResult = {
+  block: SrcBlockNode;
+  nextLineIndex: number;
+};
+
+function parseSrcBlockLine(line: string, lineNumber: number): SrcBlockLine | null {
+  const match = /^(\s*)#\+([^\s]+)(.*)$/.exec(line);
+  if (!match) return null;
+
+  const indent = match[1];
+  const keywordRaw = match[2];
+  const afterKeywordRaw = match[3];
+
+  if (indent.includes("\t") || afterKeywordRaw.includes("\t")) {
+    fail(makeError("Unsupported construct: tab character", lineNumber, line.indexOf("\t") + 1));
+  }
+
+  return { indent, keywordRaw, afterKeywordRaw };
+}
+
+function isBeginSrc(line: SrcBlockLine): boolean {
+  return line.keywordRaw.toLowerCase() === "begin_src";
+}
+
+function isEndSrc(line: SrcBlockLine): boolean {
+  return line.keywordRaw.toLowerCase() === "end_src";
+}
+
+function parseSrcBlock(lines: string[], startLineIndex: number): ParseSrcBlockResult {
+  const startLineNumber = startLineIndex + 1;
+  const begin = parseSrcBlockLine(lines[startLineIndex] ?? "", startLineNumber);
+  if (!begin || !isBeginSrc(begin)) {
+    fail(makeError("Invalid source block; expected #+begin_src", startLineNumber, 1));
+  }
+
+  for (let i = startLineIndex + 1; i < lines.length; i += 1) {
+    const lineNumber = i + 1;
+    const line = lines[i] ?? "";
+
+    const parsed = parseSrcBlockLine(line, lineNumber);
+    if (parsed && isEndSrc(parsed)) {
+      const bodyLines = lines.slice(startLineIndex + 1, i);
+      return {
+        block: {
+          type: "SrcBlock",
+          terminated: true,
+          begin,
+          bodyRaw: bodyLines.join("\n"),
+          end: parsed,
+        },
+        nextLineIndex: i + 1,
+      };
+    }
+  }
+
+  const bodyLines = lines.slice(startLineIndex + 1);
+  return {
+    block: {
+      type: "SrcBlock",
+      terminated: false,
+      begin,
+      bodyRaw: bodyLines.join("\n"),
+    },
+    nextLineIndex: lines.length,
+  };
 }
 
 export function parseOrgToCanonicalAst(input: string): DocumentNode {
@@ -212,13 +286,14 @@ export function parseOrgToCanonicalAst(input: string): DocumentNode {
     return list;
   }
 
-  function addListItem(ordered: boolean, content: string): void {
+  function addListItem(ordered: boolean, content: string): ListItemNode {
     const list = ensureList(ordered);
     const item: ListItemNode = {
       type: "ListItem",
       children: [paragraphFromText(content)],
     };
     list.items.push(item);
+    return item;
   }
 
   const lines = input.split("\n");
@@ -227,8 +302,21 @@ export function parseOrgToCanonicalAst(input: string): DocumentNode {
     const lineNumber = i + 1;
     const line = lines[i];
 
-    if (line.startsWith("#+")) {
-      fail(makeError("Unsupported construct: directive", lineNumber, 1));
+    {
+      const directive = parseSrcBlockLine(line, lineNumber);
+      if (directive) {
+        if (isBeginSrc(directive)) {
+          flushParagraph();
+          endList();
+
+          const { block, nextLineIndex } = parseSrcBlock(lines, i);
+          getChildrenArray(currentContainer()).push(block);
+          i = nextLineIndex;
+          continue;
+        }
+
+        fail(makeError("Unsupported construct: directive", lineNumber, 1));
+      }
     }
 
     if (line.startsWith("*")) {
@@ -280,8 +368,65 @@ export function parseOrgToCanonicalAst(input: string): DocumentNode {
     const listItem = parseListItemLine(line);
     if (listItem) {
       flushParagraph();
-      addListItem(listItem.ordered, listItem.content);
+      const item = addListItem(listItem.ordered, listItem.content);
       i += 1;
+
+      let itemParagraphLines: string[] = [];
+
+      function flushItemParagraph(): void {
+        if (itemParagraphLines.length === 0) return;
+        item.children.push(paragraphFromLines(itemParagraphLines));
+        itemParagraphLines = [];
+      }
+
+      while (i < lines.length) {
+        const contLineNumber = i + 1;
+        const contLine = lines[i] ?? "";
+
+        if (isBlank(contLine)) {
+          flushItemParagraph();
+          break;
+        }
+
+        if (contLine.startsWith("*")) {
+          flushItemParagraph();
+          break;
+        }
+
+        const maybeNextItem = parseListItemLine(contLine);
+        if (maybeNextItem) {
+          flushItemParagraph();
+          break;
+        }
+
+        if (!contLine.startsWith(" ".repeat(listItem.indentColumn))) {
+          flushItemParagraph();
+          break;
+        }
+
+        const directive = parseSrcBlockLine(contLine, contLineNumber);
+        if (directive && isBeginSrc(directive)) {
+          flushItemParagraph();
+          const { block, nextLineIndex } = parseSrcBlock(lines, i);
+          item.children.push(block);
+          i = nextLineIndex;
+          continue;
+        }
+
+        if (contLine.includes("\t")) {
+          fail(
+            makeError(
+              "Unsupported construct: tab character",
+              contLineNumber,
+              contLine.indexOf("\t") + 1,
+            ),
+          );
+        }
+
+        itemParagraphLines.push(contLine.slice(listItem.indentColumn));
+        i += 1;
+      }
+
       continue;
     }
 


### PR DESCRIPTION
Implements v0 support for Org SOURCE blocks (`#+begin_src` / `#+end_src`) in a lossless canonical form.

- Updates `spec/v0/SPEC.md` with SOURCE block rules + unterminated behavior
- Extends `spec/v0/canonical-ast.schema.json` + `src/ast.ts` with `SrcBlock`
- Updates `src/parser.ts` to parse `SrcBlock` nodes (including inside list items)
- Adds fixtures under `spec/v0/tests` for basic, header args, case variants, list nesting, and unterminated blocks

This PR was generated with AI assistance from openai-codex/gpt-5.2

Closes #18.