### PR TITLE
Vim plugin for Org2 (syntax + folding)

### DIFF
--- a/editors/README.md
+++ b/editors/README.md
@@ -1,3 +1,4 @@
 # Editor integrations
 
 - `vscode-org2/`: VS Code language extension (MVP)
+- `vim-org2/`: Vim filetype plugin (syntax + folding)

--- a/editors/vim-org2/README.md
+++ b/editors/vim-org2/README.md
@@ -1,0 +1,38 @@
+# Org2 (Vim)
+
+Minimal Vim plugin for Org2.
+
+## Features
+
+- Filetype detection for `*.org2`
+- Syntax highlighting (different groups per heading level)
+- Folding by heading level
+- `<Tab>` toggles the fold for the current item
+
+## Install
+
+### Vim 8+ / Neovim (native packages)
+
+Clone into a `pack/*/start/` directory:
+
+```sh
+git clone https://github.com/aviaviavi/org2.git ~/.vim/pack/plugins/start/org2
+```
+
+Then ensure the Vim runtime path includes the plugin directory:
+
+```vim
+set runtimepath^=~/.vim/pack/plugins/start/org2/editors/vim-org2
+```
+
+(Neovim: use `~/.local/share/nvim/site/pack/...` and `runtimepath` accordingly.)
+
+## Help
+
+After adding to `runtimepath`, generate helptags:
+
+```vim
+:helptags editors/vim-org2/doc
+```
+
+See `:help org2`.

--- a/editors/vim-org2/autoload/org2.vim
+++ b/editors/vim-org2/autoload/org2.vim
@@ -1,0 +1,40 @@
+" Org2 helpers
+
+if exists('*org2#foldexpr')
+  finish
+endif
+
+function! org2#_heading_level(line) abort
+  let l:stars = matchstr(a:line, '^\*\+')
+  if empty(l:stars)
+    return 0
+  endif
+  return strlen(l:stars)
+endfunction
+
+function! org2#foldexpr(lnum) abort
+  let l:line = getline(a:lnum)
+  let l:level = org2#_heading_level(l:line)
+
+  if l:level > 0
+    return '>' . l:level
+  endif
+
+  return '='
+endfunction
+
+function! org2#toggle_current_item_fold() abort
+  let l:save = getcurpos()
+
+  " Prefer toggling the fold for the current heading; otherwise use the
+  " closest heading above the cursor.
+  let l:heading_lnum = search('^\*\+\s', 'bnW')
+  if l:heading_lnum == 0
+    return
+  endif
+
+  call cursor(l:heading_lnum, 1)
+  normal! za
+
+  call setpos('.', l:save)
+endfunction

--- a/editors/vim-org2/doc/org2.txt
+++ b/editors/vim-org2/doc/org2.txt
@@ -1,0 +1,42 @@
+*org2*  Org2 filetype support for Vim
+
+CONTENTS                                                *org2-contents*
+
+  1. Overview .......................................... |org2-overview|
+  2. Folding ........................................... |org2-folding|
+  3. Syntax ............................................ |org2-syntax|
+
+
+1. Overview                                              *org2-overview*
+
+This plugin provides minimal Org2 support:
+
+- Filetype detection for *.org2
+- Syntax highlighting
+- Folding by heading level
+
+
+2. Folding                                                *org2-folding*
+
+The plugin sets:
+
+  foldmethod=expr
+  foldexpr=org2#foldexpr(v:lnum)
+
+Normal mode mapping:
+
+  <Tab>    Toggle fold for the current item.
+
+If the cursor is not on a heading, <Tab> will use the closest heading above.
+
+
+3. Syntax                                                  *org2-syntax*
+
+Headings are highlighted with separate syntax groups per level:
+
+  org2Heading1 .. org2Heading8
+
+These are linked to common Vim highlight groups by default.
+
+
+vim:tw=78:ts=8:ft=help:norl:

--- a/editors/vim-org2/ftdetect/org2.vim
+++ b/editors/vim-org2/ftdetect/org2.vim
@@ -1,0 +1,7 @@
+" Org2 filetype detection
+if exists('g:did_ftdetect_org2')
+  finish
+endif
+let g:did_ftdetect_org2 = 1
+
+autocmd BufRead,BufNewFile *.org2 setfiletype org2

--- a/editors/vim-org2/ftplugin/org2.vim
+++ b/editors/vim-org2/ftplugin/org2.vim
@@ -1,0 +1,18 @@
+" Org2 filetype plugin
+
+if exists('b:did_ftplugin_org2')
+  finish
+endif
+let b:did_ftplugin_org2 = 1
+
+setlocal foldmethod=expr
+setlocal foldexpr=org2#foldexpr(v:lnum)
+setlocal foldlevel=99
+
+" Toggle visibility (fold) of the current item's body.
+nnoremap <buffer> <Tab> :call org2#toggle_current_item_fold()<CR>
+
+" Load syntax when using :set ft=org2 manually.
+if exists('b:current_syntax') == 0
+  silent! runtime! syntax/org2.vim
+endif

--- a/editors/vim-org2/syntax/org2.vim
+++ b/editors/vim-org2/syntax/org2.vim
@@ -1,0 +1,59 @@
+" Org2 syntax highlighting
+
+if exists('b:current_syntax')
+  finish
+endif
+
+syn case match
+
+" Headings: separate groups per level.
+syn match org2Heading1 /^\*\s\+.*$/
+syn match org2Heading2 /^\*\{2}\s\+.*$/
+syn match org2Heading3 /^\*\{3}\s\+.*$/
+syn match org2Heading4 /^\*\{4}\s\+.*$/
+syn match org2Heading5 /^\*\{5}\s\+.*$/
+syn match org2Heading6 /^\*\{6}\s\+.*$/
+syn match org2Heading7 /^\*\{7}\s\+.*$/
+syn match org2Heading8 /^\*\{8}\s\+.*$/
+
+" Directives: #+NAME: value
+syn match org2Directive /^#\+[A-Za-z0-9_\-]\+:.*/
+
+" Block markers: #+BEGIN_... / #+END_...
+syn match org2BlockBegin /^#\+BEGIN_[A-Za-z0-9_\-]\+\>.*$/
+syn match org2BlockEnd /^#\+END_[A-Za-z0-9_\-]\+\>.*$/
+
+" Drawers: :PROPERTIES: / :END:
+syn match org2DrawerBegin /^:[A-Za-z0-9_\-]\+:\s*$/
+syn match org2DrawerEnd /^:END:\s*$/
+
+" Properties inside drawers: :KEY: value
+syn match org2Property /^:[A-Za-z0-9_\-]\+:\s\+.*$/
+
+" List markers and checkboxes
+syn match org2ListMarker /^\s*[-+*]\s\+/ contains=org2Checkbox
+syn match org2Checkbox /\v\[( |X|-)\]/ contained
+
+" Links: [[...]]
+syn match org2Link /\v\[\[[^\]]+\]\]/
+
+hi def link org2Heading1 Title
+hi def link org2Heading2 Statement
+hi def link org2Heading3 Identifier
+hi def link org2Heading4 Type
+hi def link org2Heading5 Constant
+hi def link org2Heading6 PreProc
+hi def link org2Heading7 Special
+hi def link org2Heading8 Comment
+
+hi def link org2Directive Keyword
+hi def link org2BlockBegin Keyword
+hi def link org2BlockEnd Keyword
+hi def link org2DrawerBegin PreProc
+hi def link org2DrawerEnd PreProc
+hi def link org2Property String
+hi def link org2ListMarker Operator
+hi def link org2Checkbox Constant
+hi def link org2Link Underlined
+
+let b:current_syntax = 'org2'


### PR DESCRIPTION
Implements #26 by adding a minimal Vim filetype plugin (ftdetect + syntax + ftplugin + help).

- Syntax highlighting with distinct groups per heading level (org2Heading1..org2Heading8)
- Folding by heading level via foldexpr
- Normal mode <Tab> toggles the current item's fold

This PR was generated with AI assistance from openai-codex/gpt-5.2