### PR TITLE
tree-sitter-org2: Neovim queries + nvim-treesitter docs

### DIFF
--- a/tree-sitter-org2/README.md
+++ b/tree-sitter-org2/README.md
@@ -13,6 +13,60 @@ The canonical definition of Org2 remains the **spec + fixtures** (and any future
 - Headlines: leading `*` stars, a single space, then title text
 - Paragraph/text lines
 
+## Neovim (nvim-treesitter)
+
+This repo includes Tree-sitter queries for Neovim under `queries/org2/`:
+
+- `queries/org2/highlights.scm`
+- `queries/org2/folds.scm`
+
+### Install the parser
+
+Because this repo currently ships only `grammar.js` (no pre-generated `src/parser.c`), `nvim-treesitter` needs to generate the C parser during installation.
+
+Add this to your Neovim config (Lua):
+
+```lua
+local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
+
+parser_config.org2 = {
+  install_info = {
+    -- This is a monorepo; point at the `tree-sitter-org2` subdir.
+    url = "https://github.com/aviaviavi/org2", 
+    files = { "src/parser.c" },
+    branch = "main",
+    generate_requires_npm = true,
+    requires_generate_from_grammar = true,
+  },
+  filetype = "org2",
+}
+
+vim.treesitter.language.register("org2", "org2")
+```
+
+Then install it:
+
+```vim
+:TSInstall org2
+```
+
+### Enable highlighting + folding
+
+Enable Tree-sitter highlighting (and optional folding):
+
+```lua
+require("nvim-treesitter.configs").setup({
+  highlight = { enable = true },
+  indent = { enable = false },
+})
+
+-- Optional: use Tree-sitter for folding.
+vim.wo.foldmethod = "expr"
+vim.wo.foldexpr = "v:lua.vim.treesitter.foldexpr()"
+```
+
+If you use a different file extension than `*.org2`, ensure your filetype is set to `org2`.
+
 ## Development
 
 ```sh

--- a/tree-sitter-org2/queries/org2/folds.scm
+++ b/tree-sitter-org2/queries/org2/folds.scm
@@ -1,0 +1,4 @@
+; Org2 Tree-sitter folds
+
+; Fold headlines (and their following content).
+(headline) @fold

--- a/tree-sitter-org2/queries/org2/highlights.scm
+++ b/tree-sitter-org2/queries/org2/highlights.scm
@@ -1,0 +1,12 @@
+; Org2 Tree-sitter highlights
+;
+; This grammar is intentionally minimal; these queries aim to provide
+; reasonable defaults for early experimentation.
+
+; Headline: stars + title
+(headline
+  stars: (stars) @punctuation.special
+  title: (title) @markup.heading)
+
+; Paragraph/text
+(text) @markup


### PR DESCRIPTION
Adds Tree-sitter query files for Neovim (highlights + folds) and documents how to install the Org2 parser via nvim-treesitter.

This PR was generated with AI assistance from openai-codex/gpt-5.2