### PR TITLE
Spec v0: timestamp printer + round-trip fixture check

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "parse": "node dist/parse.js",
+    "print": "node dist/print.js",
     "fixtures": "node tools/fixture-runner.mjs",
     "pretest": "npm run build",
     "test": "npm run fixtures"

--- a/src/print.ts
+++ b/src/print.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { printCanonicalAstToOrg } from "./printer.js";
+
+function usage(): never {
+  const cmd = path.basename(process.argv[1] ?? "print");
+  console.error(`Usage: ${cmd} <ast.json>`);
+  process.exit(2);
+}
+
+function main() {
+  const filePath = process.argv[2];
+  if (!filePath) usage();
+
+  const raw = fs.readFileSync(filePath, "utf8");
+  const ast = JSON.parse(raw);
+  const out = printCanonicalAstToOrg(ast);
+  process.stdout.write(out);
+}
+
+main();

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -1,0 +1,78 @@
+import type {
+  DocumentNode,
+  HeadlineNode,
+  InlineNode,
+  ParagraphNode,
+  TextNode,
+  TimestampNode,
+  TimestampRangeNode,
+} from "./ast.js";
+
+function printText(node: TextNode): string {
+  return node.value;
+}
+
+function printTimestamp(node: TimestampNode): string {
+  return node.raw;
+}
+
+function printTimestampRange(node: TimestampRangeNode): string {
+  return `${printTimestamp(node.start)}${node.separatorRaw}${printTimestamp(node.end)}`;
+}
+
+function printInline(node: InlineNode): string {
+  switch (node.type) {
+    case "Text":
+      return printText(node);
+    case "Timestamp":
+      return printTimestamp(node);
+    case "TimestampRange":
+      return printTimestampRange(node);
+    default: {
+      const _exhaustive: never = node;
+      return _exhaustive;
+    }
+  }
+}
+
+function printParagraph(node: ParagraphNode): string {
+  return node.children.map(printInline).join("");
+}
+
+function printHeadline(node: HeadlineNode): string {
+  const stars = "*".repeat(node.level);
+
+  const todo = node.todo ? `${node.todo} ` : "";
+  const title = node.title.map(printInline).join("");
+
+  const tags =
+    node.tags && node.tags.length > 0
+      ? ` :${node.tags.map((t) => `${t}:`).join("")}`
+      : "";
+
+  return `${stars} ${todo}${title}${tags}`;
+}
+
+export function printCanonicalAstToOrg(doc: DocumentNode): string {
+  if (doc.type !== "Document" || doc.version !== "0") {
+    throw new Error("Unsupported AST: expected Document v0");
+  }
+
+  const lines: string[] = [];
+
+  for (const child of doc.children) {
+    switch (child.type) {
+      case "Paragraph":
+        lines.push(printParagraph(child));
+        break;
+      case "Headline":
+        lines.push(printHeadline(child));
+        break;
+      default:
+        throw new Error(`Unsupported node in printer v0: ${child.type}`);
+    }
+  }
+
+  // v0 fixtures generally include a trailing newline.
+  return `${lines.join("\n\n")}\n`;
+}

--- a/tools/fixture-runner.mjs
+++ b/tools/fixture-runner.mjs
@@ -216,6 +216,13 @@ function parseOrgViaCli(parseEntrypoint, orgPath) {
   return JSON.parse(raw);
 }
 
+function printAstViaCli(printEntrypoint, jsonPath) {
+  return execFileSync(process.execPath, [printEntrypoint, jsonPath], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
 function printHelp() {
   console.log("Usage: node tools/fixture-runner.mjs [--schema-only | --e2e]");
   console.log("\nModes:");
@@ -268,10 +275,14 @@ function main() {
   }
 
   const parseEntrypoint = path.join(repoRoot, "dist", "parse.js");
+  const printEntrypoint = path.join(repoRoot, "dist", "print.js");
   const hasParser = fs.existsSync(parseEntrypoint);
+  const hasPrinter = fs.existsSync(printEntrypoint);
 
   const endToEnd =
     parsedArgs.mode === "e2e" ? hasParser : parsedArgs.mode === "auto" ? hasParser : false;
+
+  const canPrint = endToEnd && hasPrinter;
 
   if (parsedArgs.mode === "e2e" && !hasParser) {
     console.log(
@@ -344,6 +355,23 @@ function main() {
       } catch (err) {
         fail(`Schema validation failed (parsed): ${pair.orgPath}: ${err.message}`);
         continue;
+      }
+
+      // Optional printer validation: only run for timestamp fixtures for now.
+      if (canPrint && /timestamp/.test(pair.base)) {
+        let printed;
+        try {
+          printed = printAstViaCli(printEntrypoint, pair.jsonPath);
+        } catch (err) {
+          fail(`Print failed: ${pair.jsonPath}: ${err.message}`);
+          continue;
+        }
+
+        const orgRaw = fs.readFileSync(pair.orgPath, "utf8");
+        if (printed !== orgRaw) {
+          fail(`E2E print mismatch: ${pair.jsonPath} did not round-trip to ${pair.orgPath}`);
+          continue;
+        }
       }
     }
 


### PR DESCRIPTION
Implements a minimal Org printer for the v0 canonical AST, sufficient to round-trip all timestamp/date fixtures.

- Adds printCanonicalAstToOrg() for Document/Headline/Paragraph + timestamp inline nodes
- Adds dist/print.js CLI (npm run print)
- Extends fixture runner to validate parse+print round-trip for fixtures containing "timestamp"

This PR was generated with AI assistance from openai-codex/gpt-5.2