### PR TITLE
Spec + schema + parser: inline emphasis

### DIFF
--- a/spec/v0/SPEC.md
+++ b/spec/v0/SPEC.md
@@ -264,3 +264,43 @@ Examples:
 
 - `<2026-01-16 Fri>--<2026-01-18 Sun>`
 - `<2026-01-16 Fri> -- <2026-01-18 Sun>`
+
+## Inline emphasis (bold/italic/underline/strike/verbatim/code)
+
+Org2 v0 supports a limited, “80% coverage” subset of Org inline emphasis.
+
+### Markers
+
+The following emphasis markers are recognized:
+
+- `*...*` → `kind: "bold"`
+- `/.../` → `kind: "italic"`
+- `_..._` → `kind: "underline"`
+- `+...+` → `kind: "strike"`
+- `=...=` → `kind: "verbatim"`
+- `~...~` → `kind: "code"`
+
+Each emphasized span produces an `Emphasis` inline node:
+
+- `type: "Emphasis"`
+- `kind`: one of the above
+- `marker`: the opening/closing marker character
+- `content`: the raw inner bytes (v0: a string; no inline children)
+
+### Boundary rules (v0)
+
+Emphasis is only recognized when it is bounded such that it is unlikely to match “inside words”.
+
+An emphasis span starting at byte index `i` with marker `M` is valid iff:
+
+- Opening marker `M` is preceded by a boundary (start-of-string, whitespace, or non-word character).
+- The byte after opening marker is not whitespace.
+- A matching closing marker `M` exists later on the same line.
+- The byte before the closing marker is not whitespace.
+- The byte after the closing marker is a boundary (end-of-string, whitespace, or non-word character).
+
+For v0, “word character” means ASCII `[A-Za-z0-9]`.
+
+### Nesting
+
+Nesting is not supported in v0. Any marker bytes inside `content` are treated as plain text.

--- a/spec/v0/canonical-ast.schema.json
+++ b/spec/v0/canonical-ast.schema.json
@@ -217,8 +217,23 @@
       "oneOf": [
         { "$ref": "#/$defs/Text" },
         { "$ref": "#/$defs/Timestamp" },
-        { "$ref": "#/$defs/TimestampRange" }
+        { "$ref": "#/$defs/TimestampRange" },
+        { "$ref": "#/$defs/Emphasis" }
       ]
+    },
+    "Emphasis": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "kind", "marker", "content"],
+      "properties": {
+        "type": { "const": "Emphasis" },
+        "kind": {
+          "type": "string",
+          "enum": ["bold", "italic", "underline", "strike", "verbatim", "code"]
+        },
+        "marker": { "type": "string" },
+        "content": { "type": "string" }
+      }
     }
   }
 }

--- a/spec/v0/tests/0026-emphasis-basic.json
+++ b/spec/v0/tests/0026-emphasis-basic.json
@@ -1,0 +1,24 @@
+{
+  "type": "Document",
+  "version": "0",
+  "children": [
+    {
+      "type": "Paragraph",
+      "children": [
+        { "type": "Text", "value": "This is " },
+        { "type": "Emphasis", "kind": "bold", "marker": "*", "content": "bold" },
+        { "type": "Text", "value": ", " },
+        { "type": "Emphasis", "kind": "italic", "marker": "/", "content": "italic" },
+        { "type": "Text", "value": ", " },
+        { "type": "Emphasis", "kind": "underline", "marker": "_", "content": "underline" },
+        { "type": "Text", "value": ", " },
+        { "type": "Emphasis", "kind": "strike", "marker": "+", "content": "strike" },
+        { "type": "Text", "value": ", " },
+        { "type": "Emphasis", "kind": "verbatim", "marker": "=", "content": "verbatim" },
+        { "type": "Text", "value": ", and " },
+        { "type": "Emphasis", "kind": "code", "marker": "~", "content": "code" },
+        { "type": "Text", "value": "." }
+      ]
+    }
+  ]
+}

--- a/spec/v0/tests/0026-emphasis-basic.org
+++ b/spec/v0/tests/0026-emphasis-basic.org
@@ -1,0 +1,1 @@
+This is *bold*, /italic/, _underline_, +strike+, =verbatim=, and ~code~.

--- a/spec/v0/tests/0027-emphasis-punctuation.json
+++ b/spec/v0/tests/0027-emphasis-punctuation.json
@@ -1,0 +1,16 @@
+{
+  "type": "Document",
+  "version": "0",
+  "children": [
+    {
+      "type": "Paragraph",
+      "children": [
+        { "type": "Text", "value": "Wait (" },
+        { "type": "Emphasis", "kind": "bold", "marker": "*", "content": "bold" },
+        { "type": "Text", "value": ")! Also: " },
+        { "type": "Emphasis", "kind": "italic", "marker": "/", "content": "italic" },
+        { "type": "Text", "value": "!" }
+      ]
+    }
+  ]
+}

--- a/spec/v0/tests/0027-emphasis-punctuation.org
+++ b/spec/v0/tests/0027-emphasis-punctuation.org
@@ -1,0 +1,1 @@
+Wait (*bold*)! Also: /italic/!

--- a/spec/v0/tests/0028-emphasis-with-timestamp.json
+++ b/spec/v0/tests/0028-emphasis-with-timestamp.json
@@ -1,0 +1,18 @@
+{
+  "type": "Document",
+  "version": "0",
+  "children": [
+    {
+      "type": "Paragraph",
+      "children": [
+        { "type": "Text", "value": "Mix " },
+        { "type": "Emphasis", "kind": "bold", "marker": "*", "content": "one" },
+        { "type": "Text", "value": " and " },
+        { "type": "Timestamp", "active": true, "raw": "<2026-01-16 Fri>" },
+        { "type": "Text", "value": " then " },
+        { "type": "Emphasis", "kind": "bold", "marker": "*", "content": "two" },
+        { "type": "Text", "value": "." }
+      ]
+    }
+  ]
+}

--- a/spec/v0/tests/0028-emphasis-with-timestamp.org
+++ b/spec/v0/tests/0028-emphasis-with-timestamp.org
@@ -1,0 +1,1 @@
+Mix *one* and <2026-01-16 Fri> then *two*.

--- a/spec/v0/tests/0029-emphasis-invalid-boundaries.json
+++ b/spec/v0/tests/0029-emphasis-invalid-boundaries.json
@@ -1,0 +1,12 @@
+{
+  "type": "Document",
+  "version": "0",
+  "children": [
+    {
+      "type": "Paragraph",
+      "children": [
+        { "type": "Text", "value": "word*no*word * spaced * *trail*word" }
+      ]
+    }
+  ]
+}

--- a/spec/v0/tests/0029-emphasis-invalid-boundaries.org
+++ b/spec/v0/tests/0029-emphasis-invalid-boundaries.org
@@ -1,0 +1,1 @@
+word*no*word * spaced * *trail*word

--- a/spec/v0/tests/0030-emphasis-unmatched.json
+++ b/spec/v0/tests/0030-emphasis-unmatched.json
@@ -1,0 +1,12 @@
+{
+  "type": "Document",
+  "version": "0",
+  "children": [
+    {
+      "type": "Paragraph",
+      "children": [
+        { "type": "Text", "value": "This is *oops and /nope" }
+      ]
+    }
+  ]
+}

--- a/spec/v0/tests/0030-emphasis-unmatched.org
+++ b/spec/v0/tests/0030-emphasis-unmatched.org
@@ -1,0 +1,1 @@
+This is *oops and /nope

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -16,6 +16,15 @@ export type TimestampRangeNode = {
   end: TimestampNode;
 };
 
+export type EmphasisKind = "bold" | "italic" | "underline" | "strike" | "verbatim" | "code";
+
+export type EmphasisNode = {
+  type: "Emphasis";
+  kind: EmphasisKind;
+  marker: string;
+  content: string;
+};
+
 export type ParagraphNode = {
   type: "Paragraph";
   children: InlineNode[];
@@ -79,7 +88,7 @@ export type HeadlineNode = {
   children: Node[];
 };
 
-export type InlineNode = TextNode | TimestampNode | TimestampRangeNode;
+export type InlineNode = TextNode | TimestampNode | TimestampRangeNode | EmphasisNode;
 
 export type Node =
   | HeadlineNode

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,5 +1,7 @@
 import type {
   DocumentNode,
+  EmphasisKind,
+  EmphasisNode,
   HeadlineNode,
   InlineNode,
   ListItemNode,
@@ -44,6 +46,15 @@ function timestampRange(start: TimestampNode, separatorRaw: string, end: Timesta
     start,
     separatorRaw,
     end,
+  };
+}
+
+function emphasis(kind: EmphasisKind, marker: string, content: string): EmphasisNode {
+  return {
+    type: "Emphasis",
+    kind,
+    marker,
+    content,
   };
 }
 
@@ -109,6 +120,67 @@ function parseTimestampOrRangeAt(value: string, startIndex: number): ParsedTimes
   };
 }
 
+function isWordChar(ch: string): boolean {
+  return /^[A-Za-z0-9]$/.test(ch);
+}
+
+function isWhitespace(ch: string): boolean {
+  return ch === " " || ch === "\n";
+}
+
+function isBoundaryChar(ch: string | undefined): boolean {
+  if (ch === undefined) return true;
+  if (isWhitespace(ch)) return true;
+  return !isWordChar(ch);
+}
+
+type ParsedEmphasisAt = {
+  node: EmphasisNode;
+  endIndex: number;
+};
+
+const EMPHASIS_MARKERS: Array<{ marker: string; kind: EmphasisKind }> = [
+  { marker: "*", kind: "bold" },
+  { marker: "/", kind: "italic" },
+  { marker: "_", kind: "underline" },
+  { marker: "+", kind: "strike" },
+  { marker: "=", kind: "verbatim" },
+  { marker: "~", kind: "code" },
+];
+
+function parseEmphasisAt(value: string, startIndex: number): ParsedEmphasisAt | null {
+  const opener = value[startIndex];
+  const rule = EMPHASIS_MARKERS.find((r) => r.marker === opener);
+  if (!rule) return null;
+
+  const prev = startIndex > 0 ? value[startIndex - 1] : undefined;
+  const next = startIndex + 1 < value.length ? value[startIndex + 1] : undefined;
+
+  if (!isBoundaryChar(prev)) return null;
+  if (next === undefined || isWhitespace(next)) return null;
+
+  // Find the first matching closer that satisfies boundary rules.
+  for (let closeIndex = startIndex + 1; closeIndex < value.length; closeIndex += 1) {
+    if (value[closeIndex] !== opener) continue;
+
+    const beforeClose = closeIndex > startIndex + 1 ? value[closeIndex - 1] : undefined;
+    const afterClose = closeIndex + 1 < value.length ? value[closeIndex + 1] : undefined;
+
+    if (beforeClose === undefined || isWhitespace(beforeClose)) continue;
+    if (!isBoundaryChar(afterClose)) continue;
+
+    const content = value.slice(startIndex + 1, closeIndex);
+    if (content.includes("\n")) continue;
+
+    return {
+      node: emphasis(rule.kind, opener, content),
+      endIndex: closeIndex + 1,
+    };
+  }
+
+  return null;
+}
+
 function parseInlinesFromText(value: string): InlineNode[] {
   const out: InlineNode[] = [];
 
@@ -116,20 +188,31 @@ function parseInlinesFromText(value: string): InlineNode[] {
   let lastTextStart = 0;
 
   while (i < value.length) {
-    const parsed = parseTimestampOrRangeAt(value, i);
-    if (!parsed) {
-      i += 1;
+    const parsedTimestamp = parseTimestampOrRangeAt(value, i);
+    if (parsedTimestamp) {
+      if (lastTextStart < i) {
+        out.push(text(value.slice(lastTextStart, i)));
+      }
+
+      out.push(parsedTimestamp.node);
+      i = parsedTimestamp.endIndex;
+      lastTextStart = i;
       continue;
     }
 
-    if (lastTextStart < i) {
-      out.push(text(value.slice(lastTextStart, i)));
+    const parsedEmphasis = parseEmphasisAt(value, i);
+    if (parsedEmphasis) {
+      if (lastTextStart < i) {
+        out.push(text(value.slice(lastTextStart, i)));
+      }
+
+      out.push(parsedEmphasis.node);
+      i = parsedEmphasis.endIndex;
+      lastTextStart = i;
+      continue;
     }
 
-    out.push(parsed.node);
-
-    i = parsed.endIndex;
-    lastTextStart = i;
+    i += 1;
   }
 
   if (lastTextStart < value.length) {

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -2,6 +2,7 @@ import type {
   DocumentNode,
   HeadlineNode,
   InlineNode,
+  EmphasisNode,
   ParagraphNode,
   TextNode,
   TimestampNode,
@@ -20,6 +21,10 @@ function printTimestampRange(node: TimestampRangeNode): string {
   return `${printTimestamp(node.start)}${node.separatorRaw}${printTimestamp(node.end)}`;
 }
 
+function printEmphasis(node: EmphasisNode): string {
+  return `${node.marker}${node.content}${node.marker}`;
+}
+
 function printInline(node: InlineNode): string {
   switch (node.type) {
     case "Text":
@@ -28,6 +33,8 @@ function printInline(node: InlineNode): string {
       return printTimestamp(node);
     case "TimestampRange":
       return printTimestampRange(node);
+    case "Emphasis":
+      return printEmphasis(node);
     default: {
       const _exhaustive: never = node;
       return _exhaustive;

--- a/tools/fixture-runner.mjs
+++ b/tools/fixture-runner.mjs
@@ -357,8 +357,8 @@ function main() {
         continue;
       }
 
-      // Optional printer validation: only run for timestamp fixtures for now.
-      if (canPrint && /timestamp/.test(pair.base)) {
+      // Optional printer validation: only run for selected fixtures for now.
+      if (canPrint && /(timestamp|emphasis)/.test(pair.base)) {
         let printed;
         try {
           printed = printAstViaCli(printEntrypoint, pair.jsonPath);


### PR DESCRIPTION
Implements Org2 v0 inline emphasis (bold/italic/underline/strike/verbatim/code) with lossless inline nodes.

- Updates spec boundary rules and schema
- Adds fixtures (valid + invalid boundary cases)
- Extends reference parser + printer to handle Emphasis nodes
- Extends fixture runner to verify printer for emphasis fixtures

Fixes #21

This PR was generated with AI assistance from openai-codex/gpt-5.2