### PR TITLE
editors: highlight emphasis, timestamps, planning, urls

### DIFF
--- a/editors/vim-org2/syntax/org2.vim
+++ b/editors/vim-org2/syntax/org2.vim
@@ -16,26 +16,42 @@ syn match org2Heading6 /^\*\{6}\s\+.*$/
 syn match org2Heading7 /^\*\{7}\s\+.*$/
 syn match org2Heading8 /^\*\{8}\s\+.*$/
 
-" Directives: #+NAME: value
-syn match org2Directive /^#\+[A-Za-z0-9_\-]\+:.*/
+" Keyword lines / directives: #+NAME: value (case-insensitive)
+syn match org2Directive /^#\+\c[A-Za-z0-9_\-]\+:.*/
 
-" Block markers: #+BEGIN_... / #+END_...
-syn match org2BlockBegin /^#\+BEGIN_[A-Za-z0-9_\-]\+\>.*$/
-syn match org2BlockEnd /^#\+END_[A-Za-z0-9_\-]\+\>.*$/
+" Planning lines: SCHEDULED: / DEADLINE:
+syn match org2Planning /^\s*\c\(SCHEDULED\|DEADLINE\):.*/
+
+" Block markers: #+begin_... / #+end_... (case-insensitive)
+syn match org2BlockBegin /^\s*#\+\cbegin_[A-Za-z0-9_\-]\+\>.*$/
+syn match org2BlockEnd /^\s*#\+\cend_[A-Za-z0-9_\-]\+\>.*$/
 
 " Drawers: :PROPERTIES: / :END:
-syn match org2DrawerBegin /^:[A-Za-z0-9_\-]\+:\s*$/
-syn match org2DrawerEnd /^:END:\s*$/
+syn match org2DrawerBegin /^\s*:[A-Za-z0-9_\-]\+:\s*$/
+syn match org2DrawerEnd /^\s*:END:\s*$/
 
 " Properties inside drawers: :KEY: value
-syn match org2Property /^:[A-Za-z0-9_\-]\+:\s\+.*$/
+syn match org2Property /^\s*:[A-Za-z0-9_\-]\+:\s\+.*$/
 
 " List markers and checkboxes
 syn match org2ListMarker /^\s*[-+*]\s\+/ contains=org2Checkbox
 syn match org2Checkbox /\v\[( |X|-)\]/ contained
 
-" Links: [[...]]
-syn match org2Link /\v\[\[[^\]]+\]\]/
+" Timestamps: <...> and [...]
+syn match org2Timestamp /\v\<\d{4}-\d{2}-\d{2}[^>]*\>/
+syn match org2Timestamp /\v\[\d{4}-\d{2}-\d{2}[^\]]*\]/
+
+" Bracket links: [[target]] or [[target][desc]]
+syn match org2Link /\v\[\[[^\]]+\](\[[^\]]*\])?\]/
+
+" Plain URLs
+syn match org2Url /\vhttps?:\/\/\S+/
+
+" Emphasis (v0: no nesting, heuristic boundaries)
+syn match org2Bold /\v(^|[^0-9A-Za-z])\zs\*[^*\s][^*]*[^*\s]\ze\*/
+syn match org2Italic /\v(^|[^0-9A-Za-z])\zs\/[^\/\s][^\/]*[^\/\s]\ze\//
+syn match org2Underline /\v(^|[^0-9A-Za-z])\zs_[^_\s][^_]*[^_\s]\ze_/
+syn match org2Strike /\v(^|[^0-9A-Za-z])\zs\+[^\+\s][^\+]*[^\+\s]\ze\+/
 
 hi def link org2Heading1 Title
 hi def link org2Heading2 Statement
@@ -47,6 +63,7 @@ hi def link org2Heading7 Special
 hi def link org2Heading8 Comment
 
 hi def link org2Directive Keyword
+hi def link org2Planning Keyword
 hi def link org2BlockBegin Keyword
 hi def link org2BlockEnd Keyword
 hi def link org2DrawerBegin PreProc
@@ -54,6 +71,12 @@ hi def link org2DrawerEnd PreProc
 hi def link org2Property String
 hi def link org2ListMarker Operator
 hi def link org2Checkbox Constant
+hi def link org2Timestamp Number
 hi def link org2Link Underlined
+hi def link org2Url Underlined
+hi def link org2Bold Bold
+hi def link org2Italic Italic
+hi def link org2Underline Underlined
+hi def link org2Strike Error
 
 let b:current_syntax = 'org2'

--- a/editors/vscode-org2/syntaxes/org2.tmLanguage.json
+++ b/editors/vscode-org2/syntaxes/org2.tmLanguage.json
@@ -4,11 +4,14 @@
   "scopeName": "source.org2",
   "patterns": [
     { "include": "#directives" },
+    { "include": "#planning" },
     { "include": "#blocks" },
     { "include": "#headlines" },
     { "include": "#drawers" },
     { "include": "#lists" },
     { "include": "#checkboxes" },
+    { "include": "#timestamps" },
+    { "include": "#emphasis" },
     { "include": "#links" }
   ],
   "repository": {
@@ -17,6 +20,14 @@
         {
           "name": "keyword.other.directive.org2",
           "match": "^(?:\\s*)#\\+[A-Za-z0-9_\\-]+(?::\\s+.*)?$"
+        }
+      ]
+    },
+    "planning": {
+      "patterns": [
+        {
+          "name": "keyword.other.planning.org2",
+          "match": "^(?:\\s*)(?:SCHEDULED|DEADLINE):.*$"
         }
       ]
     },
@@ -33,6 +44,9 @@
             "0": { "name": "keyword.other.block.end.org2" }
           },
           "patterns": [
+            { "include": "#timestamps" },
+            { "include": "#emphasis" },
+            { "include": "#links" },
             { "name": "text.plain.org2", "match": ".+" }
           ]
         }
@@ -92,11 +106,47 @@
         }
       ]
     },
+    "timestamps": {
+      "patterns": [
+        {
+          "name": "constant.other.timestamp.org2",
+          "match": "<\\d{4}-\\d{2}-\\d{2}[^>]*>"
+        },
+        {
+          "name": "constant.other.timestamp.org2",
+          "match": "\\[\\d{4}-\\d{2}-\\d{2}[^\\]]*\\]"
+        }
+      ]
+    },
+    "emphasis": {
+      "patterns": [
+        {
+          "name": "markup.bold.org2",
+          "match": "(^|[^0-9A-Za-z])\\*[^*\\s][^*]*[^*\\s]\\*"
+        },
+        {
+          "name": "markup.italic.org2",
+          "match": "(^|[^0-9A-Za-z])\\/[^\\/\\s][^\\/]*[^\\/\\s]\\/"
+        },
+        {
+          "name": "markup.underline.org2",
+          "match": "(^|[^0-9A-Za-z])_[^_\\s][^_]*[^_\\s]_"
+        },
+        {
+          "name": "markup.strikethrough.org2",
+          "match": "(^|[^0-9A-Za-z])\\+[^\\+\\s][^\\+]*[^\\+\\s]\\+"
+        }
+      ]
+    },
     "links": {
       "patterns": [
         {
           "name": "markup.underline.link.org2",
           "match": "\\[\\[[^\\]]+\\](?:\\[[^\\]]*\\])?\\]"
+        },
+        {
+          "name": "markup.underline.link.org2",
+          "match": "https?:\\/\\/\\S+"
         }
       ]
     }


### PR DESCRIPTION
This updates the Vim and VS Code editor integrations to highlight the v0 elements we've added recently (timestamps, planning lines, emphasis, plain URLs) and makes #+ keywords / begin/end markers case-insensitive.

This PR was generated with AI assistance from openai-codex/gpt-5.2.