### PR TITLE
Spec: headline titles use inline parsing

### DIFF
--- a/spec/v0/SPEC.md
+++ b/spec/v0/SPEC.md
@@ -74,7 +74,7 @@ A **headline line** is a line that matches:
 A headline line produces a `Headline` node with:
 
 - `level`: the number of `*` characters.
-- `title`: an array of inline nodes (v0: a single `Text` node containing the title string).
+- `title`: an array of inline nodes, parsed using the same inline rules as paragraphs (timestamps, links, emphasis, etc.).
 
 ### TODO keywords (syntax only)
 

--- a/spec/v0/tests/0042-headline-inline-title.json
+++ b/spec/v0/tests/0042-headline-inline-title.json
@@ -1,0 +1,43 @@
+{
+  "type": "Document",
+  "version": "0",
+  "children": [
+    {
+      "type": "Headline",
+      "level": 1,
+      "title": [
+        {
+          "type": "Text",
+          "value": "Plan "
+        },
+        {
+          "type": "Emphasis",
+          "kind": "bold",
+          "marker": "*",
+          "content": "bold"
+        },
+        {
+          "type": "Text",
+          "value": " "
+        },
+        {
+          "type": "Timestamp",
+          "active": true,
+          "raw": "<2026-01-16 Fri>"
+        },
+        {
+          "type": "Text",
+          "value": " "
+        },
+        {
+          "type": "Link",
+          "format": "bracket",
+          "raw": "[[file:foo][desc]]",
+          "targetRaw": "file:foo",
+          "descriptionRaw": "desc"
+        }
+      ],
+      "children": []
+    }
+  ]
+}

--- a/spec/v0/tests/0042-headline-inline-title.org
+++ b/spec/v0/tests/0042-headline-inline-title.org
@@ -1,0 +1,1 @@
+* Plan *bold* <2026-01-16 Fri> [[file:foo][desc]]


### PR DESCRIPTION
Align v0 spec with existing parser behavior: headline titles are parsed using the inline grammar (links/emphasis/etc.), not treated as a single plain text node.

- Updates `spec/v0/SPEC.md`
- Adds fixture `spec/v0/tests/0042-headline-inline-title.{org,json}`

This PR was generated with AI assistance from openai-codex/gpt-5.2.