### PR TITLE
Preserve unknown #+ directives

### DIFF
--- a/spec/v0/SPEC.md
+++ b/spec/v0/SPEC.md
@@ -145,6 +145,14 @@ Example:
 
 Property drawers may appear as children of `Headline` nodes (and implementations MAY also support them at document level).
 
+## Directives (unknown #+... lines)
+
+Org2 v0 supports preserving directive lines that begin with `#+` but are not otherwise recognized as:
+- keyword lines (`#+KEY: VALUE`), or
+- structural blocks (e.g. `#+begin_src` ... `#+end_src`)
+
+Such lines MUST be represented as `DirectiveLine` nodes and preserved losslessly.
+
 ## SOURCE blocks (#+begin_src / #+end_src)
 
 Source blocks are supported as a structural syntax element.

--- a/spec/v0/canonical-ast.schema.json
+++ b/spec/v0/canonical-ast.schema.json
@@ -27,6 +27,7 @@
         { "$ref": "#/$defs/List" },
         { "$ref": "#/$defs/ListItem" },
         { "$ref": "#/$defs/KeywordLine" },
+        { "$ref": "#/$defs/DirectiveLine" },
         { "$ref": "#/$defs/Planning" },
         { "$ref": "#/$defs/PropertyDrawer" },
         { "$ref": "#/$defs/SrcBlock" },
@@ -104,6 +105,18 @@
         "indent": { "type": "string" },
         "keyRaw": { "type": "string" },
         "valueRaw": { "type": "string" }
+      }
+    },
+    "DirectiveLine": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "raw", "indent", "keywordRaw", "afterKeywordRaw"],
+      "properties": {
+        "type": { "const": "DirectiveLine" },
+        "raw": { "type": "string" },
+        "indent": { "type": "string" },
+        "keywordRaw": { "type": "string" },
+        "afterKeywordRaw": { "type": "string" }
       }
     },
     "Planning": {

--- a/spec/v0/tests/0043-unknown-directive-line.json
+++ b/spec/v0/tests/0043-unknown-directive-line.json
@@ -1,0 +1,48 @@
+{
+  "type": "Document",
+  "version": "0",
+  "children": [
+    {
+      "type": "KeywordLine",
+      "raw": "#+attr_html: :width 300",
+      "indent": "",
+      "keyRaw": "attr_html",
+      "valueRaw": " :width 300"
+    },
+    {
+      "type": "DirectiveLine",
+      "raw": "#+foo bar baz",
+      "indent": "",
+      "keywordRaw": "foo",
+      "afterKeywordRaw": " bar baz"
+    },
+    {
+      "type": "Headline",
+      "level": 1,
+      "title": [
+        {
+          "type": "Text",
+          "value": "H1"
+        }
+      ],
+      "children": [
+        {
+          "type": "DirectiveLine",
+          "raw": "#+bar_qux quux",
+          "indent": "",
+          "keywordRaw": "bar_qux",
+          "afterKeywordRaw": " quux"
+        },
+        {
+          "type": "Paragraph",
+          "children": [
+            {
+              "type": "Text",
+              "value": "A paragraph."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/v0/tests/0043-unknown-directive-line.org
+++ b/spec/v0/tests/0043-unknown-directive-line.org
@@ -1,0 +1,6 @@
+#+attr_html: :width 300
+#+foo bar baz
+
+* H1
+#+bar_qux quux
+A paragraph.

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -46,6 +46,16 @@ export type KeywordLineNode = {
   valueRaw: string;
 };
 
+// A non-block `#+...` line that does not match `#+KEY: VALUE`.
+// This is used for lossless preservation of unknown directives.
+export type DirectiveLineNode = {
+  type: "DirectiveLine";
+  raw: string;
+  indent: string;
+  keywordRaw: string;
+  afterKeywordRaw: string;
+};
+
 export type PlanningKind = "SCHEDULED" | "DEADLINE";
 
 export type PlanningNode = {
@@ -132,6 +142,7 @@ export type Node =
   | ListNode
   | ListItemNode
   | KeywordLineNode
+  | DirectiveLineNode
   | PlanningNode
   | PropertyDrawerNode
   | SrcBlockNode

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -799,7 +799,17 @@ export function parseOrgToCanonicalAst(input: string): DocumentNode {
           continue;
         }
 
-        fail(makeError("Unsupported construct: directive", lineNumber, 1));
+        flushParagraph();
+        endList();
+        getChildrenArray(currentContainer()).push({
+          type: "DirectiveLine",
+          raw: line,
+          indent: directive.indent,
+          keywordRaw: directive.keywordRaw,
+          afterKeywordRaw: directive.afterKeywordRaw,
+        });
+        i += 1;
+        continue;
       }
     }
 
@@ -908,6 +918,14 @@ export function parseOrgToCanonicalAst(input: string): DocumentNode {
         }
 
         if (directive) {
+          if (isBeginSrc(directive)) {
+            flushItemParagraph();
+            const { block, nextLineIndex } = parseSrcBlock(lines, i);
+            item.children.push(block);
+            i = nextLineIndex;
+            continue;
+          }
+
           const kind = getBlockKindFromBegin(directive);
           if (kind) {
             flushItemParagraph();
@@ -916,6 +934,17 @@ export function parseOrgToCanonicalAst(input: string): DocumentNode {
             i = nextLineIndex;
             continue;
           }
+
+          flushItemParagraph();
+          item.children.push({
+            type: "DirectiveLine",
+            raw: contLine,
+            indent: directive.indent,
+            keywordRaw: directive.keywordRaw,
+            afterKeywordRaw: directive.afterKeywordRaw,
+          });
+          i += 1;
+          continue;
         }
 
         if (matchTableLine(contLine, " ".repeat(listItem.indentColumn))) {

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -4,6 +4,7 @@ import type {
   EmphasisNode,
   HeadlineNode,
   InlineNode,
+  DirectiveLineNode,
   KeywordLineNode,
   LinkNode,
   ParagraphNode,
@@ -74,6 +75,10 @@ function printKeywordLine(node: KeywordLineNode): string {
   return node.raw;
 }
 
+function printDirectiveLine(node: DirectiveLineNode): string {
+  return node.raw;
+}
+
 function printPlanning(node: PlanningNode): string {
   return node.raw;
 }
@@ -115,6 +120,9 @@ export function printCanonicalAstToOrg(doc: DocumentNode): string {
         break;
       case "KeywordLine":
         lines.push(printKeywordLine(child));
+        break;
+      case "DirectiveLine":
+        lines.push(printDirectiveLine(child));
         break;
       case "Planning":
         lines.push(printPlanning(child));


### PR DESCRIPTION
Implements lossless preservation for unknown `#+...` directive lines by introducing a `DirectiveLine` node in the v0 canonical AST.

This PR was generated with AI assistance from openai-codex/gpt-5.2.