### PR TITLE
Preserve comment lines

### DIFF
--- a/spec/v0/SPEC.md
+++ b/spec/v0/SPEC.md
@@ -153,6 +153,12 @@ Org2 v0 supports preserving directive lines that begin with `#+` but are not oth
 
 Such lines MUST be represented as `DirectiveLine` nodes and preserved losslessly.
 
+## Comment lines
+
+A **comment line** is any line that begins with `#` but does not begin with `#+`.
+
+Comment lines MUST be represented as `CommentLine` nodes and preserved losslessly.
+
 ## SOURCE blocks (#+begin_src / #+end_src)
 
 Source blocks are supported as a structural syntax element.

--- a/spec/v0/canonical-ast.schema.json
+++ b/spec/v0/canonical-ast.schema.json
@@ -28,6 +28,7 @@
         { "$ref": "#/$defs/ListItem" },
         { "$ref": "#/$defs/KeywordLine" },
         { "$ref": "#/$defs/DirectiveLine" },
+        { "$ref": "#/$defs/CommentLine" },
         { "$ref": "#/$defs/Planning" },
         { "$ref": "#/$defs/PropertyDrawer" },
         { "$ref": "#/$defs/SrcBlock" },
@@ -117,6 +118,17 @@
         "indent": { "type": "string" },
         "keywordRaw": { "type": "string" },
         "afterKeywordRaw": { "type": "string" }
+      }
+    },
+    "CommentLine": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "raw", "indent", "bodyRaw"],
+      "properties": {
+        "type": { "const": "CommentLine" },
+        "raw": { "type": "string" },
+        "indent": { "type": "string" },
+        "bodyRaw": { "type": "string" }
       }
     },
     "Planning": {

--- a/spec/v0/tests/0044-comment-line.json
+++ b/spec/v0/tests/0044-comment-line.json
@@ -1,0 +1,21 @@
+{
+  "type": "Document",
+  "version": "0",
+  "children": [
+    {
+      "type": "CommentLine",
+      "raw": "# this is a comment",
+      "indent": "",
+      "bodyRaw": " this is a comment"
+    },
+    {
+      "type": "Paragraph",
+      "children": [
+        {
+          "type": "Text",
+          "value": "Hello"
+        }
+      ]
+    }
+  ]
+}

--- a/spec/v0/tests/0044-comment-line.org
+++ b/spec/v0/tests/0044-comment-line.org
@@ -1,0 +1,3 @@
+# this is a comment
+
+Hello

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -56,6 +56,13 @@ export type DirectiveLineNode = {
   afterKeywordRaw: string;
 };
 
+export type CommentLineNode = {
+  type: "CommentLine";
+  raw: string;
+  indent: string;
+  bodyRaw: string;
+};
+
 export type PlanningKind = "SCHEDULED" | "DEADLINE";
 
 export type PlanningNode = {
@@ -143,6 +150,7 @@ export type Node =
   | ListItemNode
   | KeywordLineNode
   | DirectiveLineNode
+  | CommentLineNode
   | PlanningNode
   | PropertyDrawerNode
   | SrcBlockNode

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,6 +1,7 @@
 import type {
   BlockKind,
   BlockNode,
+  CommentLineNode,
   DocumentNode,
   EmphasisKind,
   EmphasisNode,
@@ -341,6 +342,25 @@ function parseKeywordLine(line: string, lineNumber: number): KeywordLineNode | n
     indent,
     keyRaw,
     valueRaw,
+  };
+}
+
+function parseCommentLine(line: string, lineNumber: number): CommentLineNode | null {
+  const match = /^(\s*)#(?!\+)(.*)$/.exec(line);
+  if (!match) return null;
+
+  const indent = match[1] ?? "";
+  const bodyRaw = match[2] ?? "";
+
+  if (indent.includes("\t") || bodyRaw.includes("\t")) {
+    fail(makeError("Unsupported construct: tab character", lineNumber, line.indexOf("\t") + 1));
+  }
+
+  return {
+    type: "CommentLine",
+    raw: line,
+    indent,
+    bodyRaw,
   };
 }
 
@@ -772,6 +792,15 @@ export function parseOrgToCanonicalAst(input: string): DocumentNode {
         flushParagraph();
         endList();
         getChildrenArray(currentContainer()).push(planning);
+        i += 1;
+        continue;
+      }
+
+      const comment = parseCommentLine(line, lineNumber);
+      if (comment) {
+        flushParagraph();
+        endList();
+        getChildrenArray(currentContainer()).push(comment);
         i += 1;
         continue;
       }


### PR DESCRIPTION
Parses Org comment lines (any line starting with # but not #+) into a lossless CommentLine AST node.

This PR was generated with AI assistance from openai-codex/gpt-5.2