### PR TITLE
Preserve comment blocks

### DIFF
--- a/spec/v0/SPEC.md
+++ b/spec/v0/SPEC.md
@@ -159,6 +159,14 @@ A **comment line** is any line that begins with `#` but does not begin with `#+`
 
 Comment lines MUST be represented as `CommentLine` nodes and preserved losslessly.
 
+## Comment blocks
+
+Comment blocks are supported as a block syntax element.
+
+A **comment block** begins with `#+begin_comment` and ends with `#+end_comment`.
+
+Comment blocks MUST be represented as `Block` nodes with `kind: "comment"` and preserved losslessly.
+
 ## SOURCE blocks (#+begin_src / #+end_src)
 
 Source blocks are supported as a structural syntax element.

--- a/spec/v0/canonical-ast.schema.json
+++ b/spec/v0/canonical-ast.schema.json
@@ -210,7 +210,7 @@
       "required": ["type", "kind", "terminated", "begin", "bodyRaw", "end"],
       "properties": {
         "type": { "const": "Block" },
-        "kind": { "type": "string", "enum": ["example", "quote", "verse", "center"] },
+        "kind": { "type": "string", "enum": ["example", "quote", "verse", "center", "comment"] },
         "terminated": { "const": true },
         "begin": { "$ref": "#/$defs/SrcBlockLine" },
         "bodyRaw": { "type": "string" },
@@ -223,7 +223,7 @@
       "required": ["type", "kind", "terminated", "begin", "bodyRaw"],
       "properties": {
         "type": { "const": "Block" },
-        "kind": { "type": "string", "enum": ["example", "quote", "verse", "center"] },
+        "kind": { "type": "string", "enum": ["example", "quote", "verse", "center", "comment"] },
         "terminated": { "const": false },
         "begin": { "$ref": "#/$defs/SrcBlockLine" },
         "bodyRaw": { "type": "string" }

--- a/spec/v0/tests/0045-comment-block.json
+++ b/spec/v0/tests/0045-comment-block.json
@@ -1,0 +1,22 @@
+{
+  "type": "Document",
+  "version": "0",
+  "children": [
+    {
+      "type": "Block",
+      "kind": "comment",
+      "terminated": true,
+      "begin": {
+        "indent": "",
+        "keywordRaw": "begin_comment",
+        "afterKeywordRaw": ""
+      },
+      "bodyRaw": "this is inside",
+      "end": {
+        "indent": "",
+        "keywordRaw": "end_comment",
+        "afterKeywordRaw": ""
+      }
+    }
+  ]
+}

--- a/spec/v0/tests/0045-comment-block.org
+++ b/spec/v0/tests/0045-comment-block.org
@@ -1,0 +1,3 @@
+#+begin_comment
+this is inside
+#+end_comment

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -96,7 +96,7 @@ export type SrcBlockNode = {
   end?: SrcBlockLine;
 };
 
-export type BlockKind = "example" | "quote" | "verse" | "center";
+export type BlockKind = "example" | "quote" | "verse" | "center" | "comment";
 
 export type BlockNode = {
   type: "Block";

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -565,6 +565,7 @@ function getBlockKindFromBegin(line: SrcBlockLine): BlockKind | null {
   if (key === "begin_quote") return "quote";
   if (key === "begin_verse") return "verse";
   if (key === "begin_center") return "center";
+  if (key === "begin_comment") return "comment";
   return null;
 }
 


### PR DESCRIPTION
Parses #+begin_comment ... #+end_comment blocks into Block nodes with kind="comment".

This PR was generated with AI assistance from openai-codex/gpt-5.2