### PR TITLE
VS Code: support .org + expand highlighting + folding

### DIFF
--- a/editors/vscode-org2/package.json
+++ b/editors/vscode-org2/package.json
@@ -19,7 +19,7 @@
       {
         "id": "org2",
         "aliases": ["Org2", "org2"],
-        "extensions": [".org2"],
+        "extensions": [".org", ".org2"],
         "configuration": "./language-configuration.json"
       }
     ],


### PR DESCRIPTION
Make the Org2 VS Code extension usable for day-to-day editing:

- Associate with both `.org` and `.org2`
- Expand TextMate grammar to cover current Org2 features (comments, TODO + tags in headlines, planning incl. CLOSED, generic drawers, tables)
- Add folding for headings and list items

This PR was generated with AI assistance from openai-codex/gpt-5.2.