### PR TITLE
VS Code: expand highlighting + add folding

### DIFF
--- a/editors/vscode-org2/README.md
+++ b/editors/vscode-org2/README.md
@@ -4,8 +4,9 @@ Minimal VS Code language support for Org2.
 
 ## Features
 
-- File association for `*.org2`
-- Basic syntax highlighting (headings, directives, blocks, drawers, lists, links)
+- File association for `*.org` and `*.org2`
+- Syntax highlighting (headings, directives, blocks, drawers, lists, checkboxes, timestamps, emphasis, links, tables)
+- Folding for headings and list items
 
 ## Notes
 

--- a/editors/vscode-org2/extension.js
+++ b/editors/vscode-org2/extension.js
@@ -1,0 +1,94 @@
+const vscode = require('vscode');
+
+const headingRe = /^(\*+)\s+/;
+const listItemRe = /^(\s*)(?:[-+*]|\d+[.)])\s+/;
+
+function provideFoldingRanges(document) {
+  const lineCount = document.lineCount;
+  const folds = [];
+
+  const headingStack = [];
+  const listStack = [];
+
+  const flushStackTo = (stack, endLine) => {
+    while (stack.length > 0) {
+      const top = stack.pop();
+      if (endLine > top.startLine) {
+        folds.push(new vscode.FoldingRange(top.startLine, endLine, top.kind));
+      }
+    }
+  };
+
+  const closeHeadingsToLevel = (level, endLine) => {
+    while (headingStack.length > 0 && headingStack[headingStack.length - 1].level >= level) {
+      const top = headingStack.pop();
+      const foldEnd = endLine;
+      if (foldEnd > top.startLine) {
+        folds.push(new vscode.FoldingRange(top.startLine, foldEnd, vscode.FoldingRangeKind.Region));
+      }
+    }
+  };
+
+  const closeListsToIndent = (indent, endLine) => {
+    while (listStack.length > 0 && listStack[listStack.length - 1].indent >= indent) {
+      const top = listStack.pop();
+      if (endLine > top.startLine) {
+        folds.push(new vscode.FoldingRange(top.startLine, endLine, vscode.FoldingRangeKind.Region));
+      }
+    }
+  };
+
+  for (let i = 0; i < lineCount; i++) {
+    const text = document.lineAt(i).text;
+
+    const headingMatch = headingRe.exec(text);
+    if (headingMatch) {
+      flushStackTo(listStack, i - 1);
+      const level = headingMatch[1].length;
+      closeHeadingsToLevel(level, i - 1);
+      headingStack.push({ level, startLine: i, kind: vscode.FoldingRangeKind.Region });
+      continue;
+    }
+
+    const listMatch = listItemRe.exec(text);
+    if (listMatch) {
+      const indent = listMatch[1].length;
+
+      // If a list starts at or above a previous list indent, close previous list folds.
+      closeListsToIndent(indent, i - 1);
+      listStack.push({ indent, startLine: i, kind: vscode.FoldingRangeKind.Region });
+      continue;
+    }
+
+    // Close list folds when leaving list indentation (blank lines included).
+    if (text.trim().length === 0) {
+      continue;
+    }
+
+    // Non-list content at indentation 0 closes any top-level lists.
+    if (!/^\s+/.test(text)) {
+      closeListsToIndent(0, i - 1);
+    }
+  }
+
+  flushStackTo(listStack, lineCount - 1);
+  closeHeadingsToLevel(1, lineCount - 1);
+
+  return folds;
+}
+
+function activate(context) {
+  const selector = [{ language: 'org2' }];
+
+  const provider = {
+    provideFoldingRanges(document) {
+      return provideFoldingRanges(document);
+    },
+  };
+
+  context.subscriptions.push(vscode.languages.registerFoldingRangeProvider(selector, provider));
+}
+
+function deactivate() {}
+
+module.exports = { activate, deactivate };

--- a/editors/vscode-org2/package.json
+++ b/editors/vscode-org2/package.json
@@ -1,9 +1,11 @@
 {
   "name": "org2-vscode",
   "displayName": "Org2",
-  "description": "Org2 language support (syntax highlighting)",
+  "description": "Org2 language support (syntax highlighting + folding)",
   "version": "0.0.1",
   "publisher": "org2",
+  "main": "./extension.js",
+  "activationEvents": ["onLanguage:org2"],
   "repository": {
     "type": "git",
     "url": "https://github.com/aviaviavi/org2"

--- a/editors/vscode-org2/syntaxes/org2.tmLanguage.json
+++ b/editors/vscode-org2/syntaxes/org2.tmLanguage.json
@@ -3,11 +3,13 @@
   "name": "Org2",
   "scopeName": "source.org2",
   "patterns": [
+    { "include": "#comments" },
     { "include": "#directives" },
     { "include": "#planning" },
     { "include": "#blocks" },
     { "include": "#headlines" },
     { "include": "#drawers" },
+    { "include": "#tables" },
     { "include": "#lists" },
     { "include": "#checkboxes" },
     { "include": "#timestamps" },
@@ -15,6 +17,14 @@
     { "include": "#links" }
   ],
   "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.number-sign.org2",
+          "match": "^(?:\\s*)#(?!\\+).*$"
+        }
+      ]
+    },
     "directives": {
       "patterns": [
         {
@@ -27,7 +37,7 @@
       "patterns": [
         {
           "name": "keyword.other.planning.org2",
-          "match": "^(?:\\s*)(?:SCHEDULED|DEADLINE):.*$"
+          "match": "^(?:\\s*)(?:SCHEDULED|DEADLINE|CLOSED):.*$"
         }
       ]
     },
@@ -56,10 +66,12 @@
       "patterns": [
         {
           "name": "markup.heading.org2",
-          "match": "^(\\*+)\\s+(.+)$",
+          "match": "^(\\*+)\\s+(?:(TODO)\\s+)?(.+?)(\\s+(:[^\n:]+:)+)?$",
           "captures": {
             "1": { "name": "punctuation.definition.heading.org2" },
-            "2": { "name": "entity.name.section.org2" }
+            "2": { "name": "keyword.other.todo.org2" },
+            "3": { "name": "entity.name.section.org2" },
+            "4": { "name": "entity.other.attribute-name.tag.org2" }
           }
         }
       ]
@@ -87,6 +99,18 @@
               }
             }
           ]
+        }
+      ]
+    },
+    "tables": {
+      "patterns": [
+        {
+          "name": "meta.table.org2",
+          "match": "^(?:\\s*)\\|.*\\|\\s*$"
+        },
+        {
+          "name": "meta.table.separator.org2",
+          "match": "^(?:\\s*)\\|[-+|]+\\|\\s*$"
         }
       ]
     },


### PR DESCRIPTION
Expand the Org2 VS Code extension to cover current Org2 syntax and improve usability.

- Expand TextMate grammar: comments, TODO + tags in headlines, planning incl. CLOSED, tables
- Add folding for headings and list items

This PR was generated with AI assistance from openai-codex/gpt-5.2.