### PR TITLE
VS Code: folding also when file is in Org language mode

### DIFF
--- a/editors/vscode-org2/extension.js
+++ b/editors/vscode-org2/extension.js
@@ -78,7 +78,7 @@ function provideFoldingRanges(document) {
 }
 
 function activate(context) {
-  const selector = [{ language: 'org2' }];
+  const selector = [{ language: 'org2' }, { language: 'org' }];
 
   const provider = {
     provideFoldingRanges(document) {

--- a/editors/vscode-org2/package.json
+++ b/editors/vscode-org2/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.1",
   "publisher": "org2",
   "main": "./extension.js",
-  "activationEvents": ["onLanguage:org2"],
+  "activationEvents": ["onLanguage:org2", "onLanguage:org"],
   "repository": {
     "type": "git",
     "url": "https://github.com/aviaviavi/org2"


### PR DESCRIPTION
Fix folding not triggering when VS Code keeps `.org` files in the built-in `org` language mode (or another Org extension wins association).

- Activate on both `org2` and `org`
- Register folding provider for both language ids

This PR was generated with AI assistance from openai-codex/gpt-5.2.