### PR TITLE
VS Code: enable Tab fold toggle + ensure folding uses provider

### DIFF
--- a/editors/vscode-org2/package.json
+++ b/editors/vscode-org2/package.json
@@ -31,6 +31,18 @@
         "scopeName": "source.org2",
         "path": "./syntaxes/org2.tmLanguage.json"
       }
+    ],
+    "configurationDefaults": {
+      "[org2]": {
+        "editor.foldingStrategy": "auto"
+      }
+    },
+    "keybindings": [
+      {
+        "key": "tab",
+        "command": "editor.toggleFold",
+        "when": "editorTextFocus && !editorHasSelection && editorLangId == 'org2'"
+      }
     ]
   }
 }


### PR DESCRIPTION
Improve the Org2 VS Code experience:

- Default `editor.foldingStrategy` to `auto` for `org2` so VS Code uses our folding provider (enables folding for list items, not just headings).
- Bind `Tab` to `editor.toggleFold` in `org2` files (org-mode style fold toggle).

This PR was generated with AI assistance from openai-codex/gpt-5.2.