### PR TITLE
Parse multiple planning keywords on a single line

### DIFF
--- a/spec/v0/tests/0049-planning-multiple.json
+++ b/spec/v0/tests/0049-planning-multiple.json
@@ -1,0 +1,47 @@
+{
+  "type": "Document",
+  "version": "0",
+  "children": [
+    {
+      "type": "Headline",
+      "level": 1,
+      "title": [
+        {
+          "type": "Text",
+          "value": "Task"
+        }
+      ],
+      "children": [
+        {
+          "type": "Planning",
+          "kind": "SCHEDULED",
+          "raw": "SCHEDULED: <2026-01-22 Wed> DEADLINE: <2026-01-29 Wed>",
+          "timestamp": {
+            "type": "Timestamp",
+            "active": true,
+            "raw": "<2026-01-22 Wed>"
+          }
+        },
+        {
+          "type": "Planning",
+          "kind": "DEADLINE",
+          "raw": "SCHEDULED: <2026-01-22 Wed> DEADLINE: <2026-01-29 Wed>",
+          "timestamp": {
+            "type": "Timestamp",
+            "active": true,
+            "raw": "<2026-01-29 Wed>"
+          }
+        },
+        {
+          "type": "Paragraph",
+          "children": [
+            {
+              "type": "Text",
+              "value": "Body text"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/v0/tests/0049-planning-multiple.org
+++ b/spec/v0/tests/0049-planning-multiple.org
@@ -1,0 +1,3 @@
+* Task
+SCHEDULED: <2026-01-22 Wed> DEADLINE: <2026-01-29 Wed>
+Body text

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -365,37 +365,63 @@ function parseCommentLine(line: string, lineNumber: number): CommentLineNode | n
   };
 }
 
-function parsePlanningLine(line: string, lineNumber: number): PlanningNode | null {
-  const match = /^(\s*)(SCHEDULED|DEADLINE):(.*)$/.exec(line);
-  if (!match) return null;
+function parsePlanningLine(line: string, lineNumber: number): PlanningNode[] | null {
+  // Check if line starts with optional indentation followed by a planning keyword
+  const initialMatch = /^(\s*)(SCHEDULED|DEADLINE):/.exec(line);
+  if (!initialMatch) return null;
 
-  const indent = match[1] ?? "";
-  const kind = match[2] as PlanningKind;
+  const indent = initialMatch[1] ?? "";
 
   if (indent.includes("\t")) {
     fail(makeError("Unsupported construct: tab character", lineNumber, line.indexOf("\t") + 1));
   }
 
-  // Find the first timestamp/range in the remainder, if any.
-  const after = match[3] ?? "";
-  let ts;
-
-  for (let i = 0; i < after.length; i += 1) {
-    const ch = after[i];
-    if (ch !== "<" && ch !== "[") continue;
-    const parsed = parseTimestampOrRangeAt(after, i);
-    if (parsed) {
-      ts = parsed.node;
-      break;
+  // Parse all planning keywords from the line
+  const planningNodes: PlanningNode[] = [];
+  
+  // Find all occurrences of SCHEDULED: or DEADLINE: in the line
+  let pos = 0;
+  while (true) {
+    const keywordMatch = /(SCHEDULED|DEADLINE):/.exec(line.slice(pos));
+    if (!keywordMatch) break;
+    
+    const kind = keywordMatch[1] as PlanningKind;
+    const startPos = pos + keywordMatch.index;
+    const afterKeywordPos = startPos + keywordMatch[0].length;
+    
+    // Extract the portion from this keyword to the start of the next keyword or end of line
+    let endPos = line.length;
+    const nextKeywordMatch = /(SCHEDULED|DEADLINE):/.exec(line.slice(afterKeywordPos));
+    if (nextKeywordMatch) {
+      endPos = afterKeywordPos + nextKeywordMatch.index;
     }
+    
+    const after = line.slice(afterKeywordPos, endPos).trim();
+
+    // Find the first timestamp/range in the remainder, if any.
+    let ts;
+    for (let i = 0; i < after.length; i += 1) {
+      const ch = after[i];
+      if (ch !== "<" && ch !== "[") continue;
+      const parsed = parseTimestampOrRangeAt(after, i);
+      if (parsed) {
+        ts = parsed.node;
+        break;
+      }
+    }
+
+    planningNodes.push({
+      type: "Planning",
+      kind,
+      raw: line,
+      ...(ts ? { timestamp: ts } : {}),
+    });
+    
+    // Move position to after this keyword for next iteration
+    pos = afterKeywordPos;
   }
 
-  return {
-    type: "Planning",
-    kind,
-    raw: line,
-    ...(ts ? { timestamp: ts } : {}),
-  };
+  return planningNodes.length > 0 ? planningNodes : null;
 }
 
 function parseHeadline(
@@ -856,7 +882,7 @@ export function parseOrgToCanonicalAst(input: string): DocumentNode {
       if (planning) {
         flushParagraph();
         endList();
-        getChildrenArray(currentContainer()).push(planning);
+        getChildrenArray(currentContainer()).push(...planning);
         i += 1;
         continue;
       }

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -57,6 +57,35 @@ function printParagraph(node: ParagraphNode): string {
   return node.children.map(printInline).join("");
 }
 
+function printNode(node: any): string {
+  switch (node.type) {
+    case "Paragraph":
+      return printParagraph(node);
+    case "Headline":
+      return printHeadline(node);
+    case "KeywordLine":
+      return printKeywordLine(node);
+    case "DirectiveLine":
+      return printDirectiveLine(node);
+    case "Planning":
+      return printPlanning(node);
+    case "Block":
+      return printBlock(node);
+    case "CommentLine":
+      return node.raw;
+    case "PropertyDrawer":
+    case "Drawer":
+    case "SrcBlock":
+    case "Table":
+    case "List":
+    case "ListItem":
+      // These nodes have raw representations or need special handling
+      return node.raw ?? "";
+    default:
+      throw new Error(`Unsupported node in printer: ${node.type}`);
+  }
+}
+
 function printHeadline(node: HeadlineNode): string {
   const stars = "*".repeat(node.level);
 
@@ -68,7 +97,32 @@ function printHeadline(node: HeadlineNode): string {
       ? ` :${node.tags.map((t) => `${t}:`).join("")}`
       : "";
 
-  return `${stars} ${todo}${title}${tags}`;
+  const headlineLine = `${stars} ${todo}${title}${tags}`;
+  
+  // Print children if any
+  if (!node.children || node.children.length === 0) {
+    return headlineLine;
+  }
+
+  const childLines: string[] = [];
+  let lastRaw: string | undefined;
+  for (const child of node.children) {
+    // Deduplicate consecutive Planning nodes with the same raw value
+    if (child.type === "Planning" && child.raw === lastRaw) {
+      // Skip this node since it's a duplicate of the previous planning line
+      continue;
+    }
+    
+    if (child.type === "Planning") {
+      lastRaw = child.raw;
+    } else {
+      lastRaw = undefined;
+    }
+    
+    childLines.push(printNode(child));
+  }
+
+  return [headlineLine, ...childLines].join("\n");
 }
 
 function printKeywordLine(node: KeywordLineNode): string {


### PR DESCRIPTION
## Summary

Add support for parsing multiple SCHEDULED/DEADLINE keywords on the same line, such as `SCHEDULED: <2026-01-22 Wed> DEADLINE: <2026-01-29 Wed>`.

This closes part of issue #36, specifically the P2 item about "Planning line indentation + multiple planning tokens on one line" (the indentation part was done in #41, this PR completes the "multiple tokens" part).

## Changes

1. **Parser enhancement (parsePlanningLine)**:
   - Modified to extract all planning keywords from a single line
   - Returns an array of Planning nodes (one per keyword)
   - Each node preserves the full original line in its 'raw' field

2. **Parser integration**:
   - Updated the line processing loop to spread returned Planning nodes into the children array
   - Allows multiple Planning nodes to be created from a single source line

3. **Printer fixes**:
   - Fixed printer's printHeadline() to recursively print headline children (previously incomplete)
   - Added printNode() helper to handle all node types
   - Implemented deduplication: consecutive Planning nodes with identical raw values are de-duplicated to avoid printing the same line multiple times

4. **Test fixture**:
   - Added test 0049-planning-multiple.org/json to validate the feature
   - Tests parsing of `SCHEDULED: <2026-01-22 Wed> DEADLINE: <2026-01-29 Wed>` on a headline

## Acceptance Criteria

- [x] Parser extracts multiple planning keywords from one line
- [x] Each keyword produces a separate Planning AST node
- [x] Original line is preserved in 'raw' field
- [x] Printer correctly round-trips the AST back to Org format (no duplicated lines)
- [x] All existing tests pass
- [x] New fixture test 0049-planning-multiple validates the feature
- [x] npm test passes

## Testing

To test this feature:
\`\`\`bash
npm test  # All 52 fixtures pass
\`\`\`

The new fixture `spec/v0/tests/0049-planning-multiple.org` demonstrates the feature with a headline containing both SCHEDULED and DEADLINE keywords on the same line.

---

This PR was generated with AI assistance from GPT-5.2
