### PR TITLE
v0: inline emphasis + links fixtures

### DIFF
--- a/spec/v0/SPEC.md
+++ b/spec/v0/SPEC.md
@@ -359,6 +359,23 @@ A **plain URL** is recognized when it begins with `http://` or `https://` and ex
 
 To reduce accidental captures, the reference parser trims common trailing punctuation characters from the URL.
 
+### Parsing order (deterministic disambiguation)
+
+When parsing inline content, the parser applies transformations in a deterministic order to avoid ambiguities:
+
+1. **Timestamps** are recognized first (both active and inactive)
+2. **Bracket links** are recognized next (before emphasis)
+3. **Plain URLs** are recognized (before emphasis)
+4. **Emphasis** markers are recognized last, respecting boundary rules
+
+This order ensures that:
+- Links take precedence over emphasis (e.g., `[[url][*text*]]` parses as a link, not emphasis within a link)
+- URLs are not split by emphasis markers
+- Timestamps are not confused with emphasis markers
+- Boundary rules are consistently applied
+
+Within emphasis parsing, all marker types (`*`, `/`, `_`, `+`, `=`, `~`) are processed with equal priority, processing left-to-right as they appear on the line.
+
 ## Keyword lines (#+KEY: VALUE)
 
 Org2 v0 supports capturing file-level keyword/metadata lines as explicit nodes.

--- a/spec/v0/tests/0067-emphasis-and-links.json
+++ b/spec/v0/tests/0067-emphasis-and-links.json
@@ -1,0 +1,56 @@
+{
+  "type": "Document",
+  "version": "0",
+  "children": [
+    {
+      "type": "Paragraph",
+      "children": [
+        {
+          "type": "Text",
+          "value": "This has "
+        },
+        {
+          "type": "Emphasis",
+          "kind": "bold",
+          "marker": "*",
+          "content": "bold text"
+        },
+        {
+          "type": "Text",
+          "value": " and "
+        },
+        {
+          "type": "Link",
+          "format": "bracket",
+          "raw": "[[https://example.com][a link]]",
+          "targetRaw": "https://example.com",
+          "descriptionRaw": "a link"
+        },
+        {
+          "type": "Text",
+          "value": ".\nAlso "
+        },
+        {
+          "type": "Emphasis",
+          "kind": "italic",
+          "marker": "/",
+          "content": "italic"
+        },
+        {
+          "type": "Text",
+          "value": " with a plain URL "
+        },
+        {
+          "type": "Link",
+          "format": "plain",
+          "raw": "https://example.org",
+          "targetRaw": "https://example.org"
+        },
+        {
+          "type": "Text",
+          "value": " here."
+        }
+      ]
+    }
+  ]
+}

--- a/spec/v0/tests/0067-emphasis-and-links.org
+++ b/spec/v0/tests/0067-emphasis-and-links.org
@@ -1,0 +1,2 @@
+This has *bold text* and [[https://example.com][a link]].
+Also /italic/ with a plain URL https://example.org here.

--- a/spec/v0/tests/0068-emphasis-links-in-lists.json
+++ b/spec/v0/tests/0068-emphasis-links-in-lists.json
@@ -1,0 +1,91 @@
+{
+  "type": "Document",
+  "version": "0",
+  "children": [
+    {
+      "type": "List",
+      "ordered": false,
+      "items": [
+        {
+          "type": "ListItem",
+          "children": [
+            {
+              "type": "Paragraph",
+              "children": [
+                {
+                  "type": "Text",
+                  "value": "This is "
+                },
+                {
+                  "type": "Emphasis",
+                  "kind": "bold",
+                  "marker": "*",
+                  "content": "bold"
+                },
+                {
+                  "type": "Text",
+                  "value": " in a list"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "ListItem",
+          "children": [
+            {
+              "type": "Paragraph",
+              "children": [
+                {
+                  "type": "Text",
+                  "value": "Visit "
+                },
+                {
+                  "type": "Link",
+                  "format": "bracket",
+                  "raw": "[[https://example.com][the site]]",
+                  "targetRaw": "https://example.com",
+                  "descriptionRaw": "the site"
+                },
+                {
+                  "type": "Text",
+                  "value": " for more"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "ListItem",
+          "children": [
+            {
+              "type": "Paragraph",
+              "children": [
+                {
+                  "type": "Emphasis",
+                  "kind": "italic",
+                  "marker": "/",
+                  "content": "Italic text"
+                },
+                {
+                  "type": "Text",
+                  "value": " with "
+                },
+                {
+                  "type": "Link",
+                  "format": "plain",
+                  "raw": "https://example.org",
+                  "targetRaw": "https://example.org"
+                },
+                {
+                  "type": "Text",
+                  "value": " url"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/v0/tests/0068-emphasis-links-in-lists.org
+++ b/spec/v0/tests/0068-emphasis-links-in-lists.org
@@ -1,0 +1,3 @@
+- This is *bold* in a list
+- Visit [[https://example.com][the site]] for more
+- /Italic text/ with https://example.org url


### PR DESCRIPTION
## Plan
- Add fixtures covering emphasis+links edge cases
- Document deterministic parsing/disambiguation rules in spec/v0/SPEC.md
- Ensure parse+print round-trip stays lossless
- Ensure npm test passes

This PR was generated with AI assistance from GPT-5.2
