### PR TITLE
feat: CLI config discovery and archive diff output

### DIFF
--- a/org2.json.example
+++ b/org2.json.example
@@ -1,0 +1,5 @@
+{
+  "agendaFiles": ["*.org", "notes/**/*.org", "agenda/*"],
+  "recursive": true,
+  "ignorePatterns": [".git/**", "node_modules/**", ".#*", "*_archive", "*.archive"]
+}

--- a/spec/v0/tests/cli/simple-agenda.expected.json.txt
+++ b/spec/v0/tests/cli/simple-agenda.expected.json.txt
@@ -1,4 +1,5 @@
 {
+  "$schema": "org2:agenda:v1",
   "range": {
     "start": "2026-01-21",
     "end": "2026-01-22",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { parseOrgToCanonicalAst } from "./parser.js";
+import { findConfigFile, loadConfig, resolveFilesFromConfig } from "./config.js";
 import type {
   DocumentNode,
   HeadlineNode,
@@ -131,6 +132,34 @@ function formatSectionHeader(title: string): string {
   return `\n${separator}\n ${title}\n${separator}\n\n`;
 }
 
+/**
+ * Generate unified diff format for archive output.
+ */
+function formatArchiveDiff(
+  sourcePath: string,
+  archivePath: string,
+  subtreeText: string
+): string {
+  let diff = `--- ${sourcePath}\n`;
+  diff += `+++ ${archivePath}\n`;
+
+  // Show what's being removed from source
+  const subtreeLines = subtreeText.split("\n");
+
+  diff += `@@ archive @@\n`;
+  diff += `--- ${sourcePath} (removed lines)\n`;
+  for (const line of subtreeLines) {
+    if (line) diff += `- ${line}\n`;
+  }
+
+  diff += `\n+++ ${archivePath} (appended lines)\n`;
+  for (const line of subtreeLines) {
+    if (line) diff += `+ ${line}\n`;
+  }
+
+  return diff;
+}
+
 function formatOutput(items: ScheduledItem[], startDate: Date): string {
   if (items.length === 0) {
     return "No scheduled items in range.\n";
@@ -204,6 +233,7 @@ async function main(): Promise<void> {
   let archiveFile = "";
   let archivePos = "";
   let archiveApply = false;
+  let archiveFormat: "text" | "diff" = "text";
 
   // Parse arguments
   let i = 0;
@@ -254,7 +284,9 @@ async function main(): Promise<void> {
       i++;
       if (i < args.length) {
         const v = args[i];
-        if (v === "text" || v === "json") {
+        if (command === "archive" && (v === "text" || v === "diff")) {
+          archiveFormat = v as "text" | "diff";
+        } else if (command === "agenda" && (v === "text" || v === "json")) {
           format = v;
         }
         i++;
@@ -296,7 +328,7 @@ async function main(): Promise<void> {
       "Usage: org2 agenda [--dir DIR] [--recursive] [--files FILE ...] [--days N] [--today YYYY-MM-DD] [--format text|json] [--no-overdue] [--verbose-errors]",
     );
     console.error(
-      "       org2 archive --file FILE --pos LINE[:COL] [--archive-file FILE] [--apply]",
+      "       org2 archive --file FILE --pos LINE[:COL] [--archive-file FILE] [--format text|diff] [--apply]",
     );
     process.exit(1);
   }
@@ -357,6 +389,13 @@ async function main(): Promise<void> {
     const subtreeText = subtreeLines.join("\n").trimEnd() + "\n";
     const newSourceText = remainingLines.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd() + "\n";
 
+    // Handle --format diff
+    if (archiveFormat === "diff") {
+      const diffOutput = formatArchiveDiff(sourcePath, archivePath, subtreeText);
+      process.stdout.write(diffOutput);
+      return;
+    }
+
     if (!archiveApply) {
       process.stdout.write(
         `Would archive subtree starting at ${sourcePath}:${headlineLineIndex + 1} to ${archivePath}\n` +
@@ -378,8 +417,28 @@ async function main(): Promise<void> {
   // agenda
   // Determine files to process
   if (!dir && files.length === 0) {
-    console.error("Error: provide either --dir or --files");
-    process.exit(1);
+    // Try to load from config
+    const configPath = findConfigFile(process.cwd());
+    if (configPath) {
+      try {
+        const config = loadConfig(configPath);
+        const configDir = path.dirname(configPath);
+        files = resolveFilesFromConfig(config, configDir);
+
+        if (files.length === 0) {
+          console.error(
+            `Error: config found at ${configPath} but no matching files for patterns: ${config.agendaFiles?.join(", ") || "*.org"}`,
+          );
+          process.exit(1);
+        }
+      } catch (err) {
+        console.error(`Error loading config: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+      }
+    } else {
+      console.error("Error: provide either --dir, --files, or org2.json config");
+      process.exit(1);
+    }
   }
 
   if (dir && files.length === 0) {
@@ -466,6 +525,7 @@ async function main(): Promise<void> {
     };
 
     const payload = {
+      $schema: "org2:agenda:v1",
       range: { start: startIso, end: endIso, days },
       overdue: group(overdue),
       days: group(upcoming),

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,138 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export interface Org2Config {
+  agendaFiles?: string[];
+  recursive?: boolean;
+  ignorePatterns?: string[];
+}
+
+export function findConfigFile(startDir: string): string | null {
+  let currentDir = path.resolve(startDir);
+
+  for (let i = 0; i < 10; i++) {
+    const configPath = path.join(currentDir, "org2.json");
+    if (fs.existsSync(configPath)) {
+      return configPath;
+    }
+
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      break;
+    }
+    currentDir = parentDir;
+  }
+
+  return null;
+}
+
+export function loadConfig(configPath: string): Org2Config {
+  try {
+    const content = fs.readFileSync(configPath, "utf8");
+    return JSON.parse(content) as Org2Config;
+  } catch (err) {
+    throw new Error(
+      `Failed to load config from ${configPath}: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}
+
+export function getDefaultConfig(): Org2Config {
+  return {
+    agendaFiles: ["*.org"],
+    recursive: true,
+    ignorePatterns: [".git/**", "node_modules/**", ".#*"],
+  };
+}
+
+function matchesPattern(filePath: string, pattern: string): boolean {
+  if (pattern.includes("**")) {
+    const parts = pattern.split("**");
+    if (parts.length === 2) {
+      const prefix = parts[0].replace(/\/$/, "");
+      const suffix = parts[1].replace(/^\//, "");
+
+      if (prefix && !filePath.startsWith(prefix)) return false;
+      if (suffix) {
+        const remaining = filePath.slice(prefix ? prefix.length + 1 : 0);
+        return (
+          suffix === "*" ||
+          remaining.endsWith(suffix) ||
+          new RegExp(`.*${suffix.replace(/\./g, "\\.")}$`).test(remaining)
+        );
+      }
+      return true;
+    }
+  }
+
+  if (pattern.startsWith("*.")) {
+    const ext = pattern.slice(1);
+    return filePath.endsWith(ext);
+  }
+
+  return filePath === pattern || filePath.startsWith(pattern + "/");
+}
+
+function shouldIgnore(filePath: string, ignorePatterns: string[]): boolean {
+  for (const pattern of ignorePatterns) {
+    if (matchesPattern(filePath, pattern)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function resolveFilesFromDir(
+  dir: string,
+  patterns: string[],
+  ignorePatterns: string[],
+  recursive: boolean = true
+): string[] {
+  const allFiles: string[] = [];
+
+  function walk(currentPath: string, relPath: string = ""): void {
+    try {
+      const entries = fs.readdirSync(currentPath, { withFileTypes: true });
+
+      for (const entry of entries) {
+        const fullPath = path.join(currentPath, entry.name);
+        const relativePath = relPath ? path.join(relPath, entry.name) : entry.name;
+
+        if (shouldIgnore(relativePath, ignorePatterns)) {
+          continue;
+        }
+
+        if (entry.isDirectory()) {
+          if (recursive && !entry.name.startsWith(".")) {
+            walk(fullPath, relativePath);
+          }
+        } else if (entry.isFile()) {
+          for (const pattern of patterns) {
+            if (matchesPattern(relativePath, pattern)) {
+              allFiles.push(path.resolve(fullPath));
+              break;
+            }
+          }
+        }
+      }
+    } catch (err) {
+      console.error(
+        `Error reading directory ${currentPath}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  walk(dir);
+  return allFiles.sort();
+}
+
+export function resolveFilesFromConfig(
+  config: Org2Config,
+  baseDir: string = process.cwd()
+): string[] {
+  const patterns = config.agendaFiles || ["*.org"];
+  const ignorePatterns = config.ignorePatterns || [];
+  const recursive = config.recursive !== false;
+
+  return resolveFilesFromDir(baseDir, patterns, ignorePatterns, recursive);
+}


### PR DESCRIPTION
## Summary

Implements initial scope for issue #59: CLI patch-based operations and config.

### Features

1. **Config Discovery** ()
   - Auto-discover  walking up directory tree
   - Fields:  (glob patterns), , 
   - Agenda uses config when / omitted

2. **Archive Diff Output**
   - New `--format diff` for archive command
   - Shows patch without applying (complements `--apply`)
   - Useful for reviewing changes before committing

3. **JSON Schema Stability**
   - Add `$schema: "org2:agenda:v1"` field for version detection
   - Enables future breaking changes with schema versioning

### Example org2.json

```json
{
  "agendaFiles": ["*.org", "notes/**/*.org"],
  "recursive": true,
  "ignorePatterns": [".git/**", "node_modules/**", ".#*"]
}
```

### Usage

```bash
# Auto-discover from org2.json
org2 agenda

# Show patch before archiving
org2 archive --file tasks.org --pos 5 --format diff

# Apply archive after review
org2 archive --file tasks.org --pos 5 --apply
```

### Tests

All existing tests pass. Updated JSON schema test expectation to include new $schema field.

This PR was generated with AI assistance from GPT-5.2