### PR TITLE
VS Code Org2: clickable org links, leveled headings, fold :PROPERTIES:

### DIFF
--- a/editors/vscode-org2/extension.js
+++ b/editors/vscode-org2/extension.js
@@ -1,7 +1,32 @@
 const vscode = require('vscode');
+const path = require('path');
 
 const headingRe = /^(\*+)\s+/;
 const listItemRe = /^(\s*)(?:[-+*]|\d+[.)])\s+/;
+const propertiesBeginRe = /^\s*:PROPERTIES:\s*$/i;
+const drawerEndRe = /^\s*:END:\s*$/i;
+
+function findPropertyDrawerStartLines(document) {
+  const starts = [];
+  const lineCount = document.lineCount;
+
+  let inProperties = false;
+  for (let i = 0; i < lineCount; i++) {
+    const text = document.lineAt(i).text;
+
+    if (!inProperties && propertiesBeginRe.test(text)) {
+      inProperties = true;
+      starts.push(i);
+      continue;
+    }
+
+    if (inProperties && drawerEndRe.test(text)) {
+      inProperties = false;
+    }
+  }
+
+  return starts;
+}
 
 function provideFoldingRanges(document) {
   const lineCount = document.lineCount;
@@ -9,6 +34,9 @@ function provideFoldingRanges(document) {
 
   const headingStack = [];
   const listStack = [];
+
+  // :PROPERTIES: drawers only (do not fold arbitrary drawers).
+  const propertiesStack = [];
 
   const flushStackTo = (stack, endLine) => {
     while (stack.length > 0) {
@@ -38,8 +66,30 @@ function provideFoldingRanges(document) {
     }
   };
 
+  const closePropertiesTo = (endLine) => {
+    while (propertiesStack.length > 0) {
+      const top = propertiesStack.pop();
+      if (endLine > top.startLine) {
+        folds.push(new vscode.FoldingRange(top.startLine, endLine, vscode.FoldingRangeKind.Region));
+      }
+    }
+  };
+
   for (let i = 0; i < lineCount; i++) {
     const text = document.lineAt(i).text;
+
+    // Property drawer folding (:PROPERTIES: ... :END:)
+    if (propertiesBeginRe.test(text)) {
+      propertiesStack.push({ startLine: i, kind: vscode.FoldingRangeKind.Region });
+      continue;
+    }
+    if (drawerEndRe.test(text) && propertiesStack.length > 0) {
+      const top = propertiesStack.pop();
+      if (i > top.startLine) {
+        folds.push(new vscode.FoldingRange(top.startLine, i, vscode.FoldingRangeKind.Region));
+      }
+      continue;
+    }
 
     const headingMatch = headingRe.exec(text);
     if (headingMatch) {
@@ -73,20 +123,118 @@ function provideFoldingRanges(document) {
 
   flushStackTo(listStack, lineCount - 1);
   closeHeadingsToLevel(1, lineCount - 1);
+  closePropertiesTo(lineCount - 1);
 
   return folds;
+}
+
+function resolveOrg2LinkTarget(rawUrl, document) {
+  const url = (rawUrl || '').trim();
+  if (!url) return undefined;
+
+  // Heuristic: if it looks like it has a scheme, let VS Code/URI parser handle it.
+  // Examples: https://..., http://..., mailto:..., file:..., vscode:...
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(url)) {
+    try {
+      return vscode.Uri.parse(url, true);
+    } catch (e) {
+      return undefined;
+    }
+  }
+
+  // Otherwise treat it as a filesystem path relative to the current document.
+  if (document.uri && document.uri.scheme === 'file') {
+    const baseDir = path.dirname(document.uri.fsPath);
+    const fsPath = path.resolve(baseDir, url);
+    return vscode.Uri.file(fsPath);
+  }
+
+  return undefined;
+}
+
+function provideDocumentLinks(document) {
+  const links = [];
+
+  // Org2 links: [[url]] or [[url][desc]]
+  const org2LinkRe = /\[\[([^\]\n]+)\](?:\[([^\]\n]*)\])?\]/g;
+  const bareUrlRe = /\bhttps?:\/\/[^\s<>()\[\]{}]+/g;
+
+  for (let line = 0; line < document.lineCount; line++) {
+    const text = document.lineAt(line).text;
+
+    for (const re of [org2LinkRe, bareUrlRe]) {
+      re.lastIndex = 0;
+      let m;
+      while ((m = re.exec(text)) !== null) {
+        const start = m.index;
+        const end = m.index + m[0].length;
+
+        const targetUrl = re === org2LinkRe ? m[1] : m[0];
+        const target = resolveOrg2LinkTarget(targetUrl, document);
+        if (!target) continue;
+
+        links.push(new vscode.DocumentLink(new vscode.Range(line, start, line, end), target));
+      }
+    }
+  }
+
+  return links;
 }
 
 function activate(context) {
   const selector = [{ language: 'org2' }, { language: 'org' }];
 
-  const provider = {
+  const foldingProvider = {
     provideFoldingRanges(document) {
       return provideFoldingRanges(document);
     },
   };
 
-  context.subscriptions.push(vscode.languages.registerFoldingRangeProvider(selector, provider));
+  context.subscriptions.push(vscode.languages.registerFoldingRangeProvider(selector, foldingProvider));
+
+  const linkProvider = {
+    provideDocumentLinks(document) {
+      return provideDocumentLinks(document);
+    },
+  };
+
+  context.subscriptions.push(vscode.languages.registerDocumentLinkProvider(selector, linkProvider));
+
+  // Fold :PROPERTIES: drawers by default (once per document URI).
+  const foldedPropertyDrawersForDoc = new Set();
+
+  const maybeFoldPropertyDrawers = async (editor) => {
+    if (!editor) return;
+    const doc = editor.document;
+    if (!doc) return;
+    if (doc.languageId !== 'org2' && doc.languageId !== 'org') return;
+
+    const key = doc.uri.toString();
+    if (foldedPropertyDrawersForDoc.has(key)) return;
+
+    const startLines = findPropertyDrawerStartLines(doc);
+    if (startLines.length === 0) {
+      foldedPropertyDrawersForDoc.add(key);
+      return;
+    }
+
+    // Mark before folding to avoid repeated attempts on rapid focus changes.
+    foldedPropertyDrawersForDoc.add(key);
+
+    // Defer folding slightly to allow VS Code to compute folding ranges.
+    setTimeout(() => {
+      vscode.commands.executeCommand('editor.fold', { selectionLines: startLines });
+    }, 0);
+  };
+
+  context.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor((editor) => {
+      maybeFoldPropertyDrawers(editor);
+    })
+  );
+
+  // Also attempt folding for already-visible editors at activation.
+  vscode.window.visibleTextEditors.forEach((ed) => maybeFoldPropertyDrawers(ed));
 
   context.subscriptions.push(
     vscode.commands.registerCommand('org2.debugFoldingRanges', () => {

--- a/editors/vscode-org2/syntaxes/org2.tmLanguage.json
+++ b/editors/vscode-org2/syntaxes/org2.tmLanguage.json
@@ -65,8 +65,68 @@
     "headlines": {
       "patterns": [
         {
+          "name": "markup.heading.1.org2",
+          "match": "^(\\*)\\s+(?:(TODO)\\s+)?(.+?)(\\s+(:[^\\n:]+:)+)?$",
+          "captures": {
+            "1": { "name": "punctuation.definition.heading.org2" },
+            "2": { "name": "keyword.other.todo.org2" },
+            "3": { "name": "entity.name.section.org2" },
+            "4": { "name": "entity.other.attribute-name.tag.org2" }
+          }
+        },
+        {
+          "name": "markup.heading.2.org2",
+          "match": "^(\\*\\*)\\s+(?:(TODO)\\s+)?(.+?)(\\s+(:[^\\n:]+:)+)?$",
+          "captures": {
+            "1": { "name": "punctuation.definition.heading.org2" },
+            "2": { "name": "keyword.other.todo.org2" },
+            "3": { "name": "entity.name.section.org2" },
+            "4": { "name": "entity.other.attribute-name.tag.org2" }
+          }
+        },
+        {
+          "name": "markup.heading.3.org2",
+          "match": "^(\\*\\*\\*)\\s+(?:(TODO)\\s+)?(.+?)(\\s+(:[^\\n:]+:)+)?$",
+          "captures": {
+            "1": { "name": "punctuation.definition.heading.org2" },
+            "2": { "name": "keyword.other.todo.org2" },
+            "3": { "name": "entity.name.section.org2" },
+            "4": { "name": "entity.other.attribute-name.tag.org2" }
+          }
+        },
+        {
+          "name": "markup.heading.4.org2",
+          "match": "^(\\*\\*\\*\\*)\\s+(?:(TODO)\\s+)?(.+?)(\\s+(:[^\\n:]+:)+)?$",
+          "captures": {
+            "1": { "name": "punctuation.definition.heading.org2" },
+            "2": { "name": "keyword.other.todo.org2" },
+            "3": { "name": "entity.name.section.org2" },
+            "4": { "name": "entity.other.attribute-name.tag.org2" }
+          }
+        },
+        {
+          "name": "markup.heading.5.org2",
+          "match": "^(\\*\\*\\*\\*\\*)\\s+(?:(TODO)\\s+)?(.+?)(\\s+(:[^\\n:]+:)+)?$",
+          "captures": {
+            "1": { "name": "punctuation.definition.heading.org2" },
+            "2": { "name": "keyword.other.todo.org2" },
+            "3": { "name": "entity.name.section.org2" },
+            "4": { "name": "entity.other.attribute-name.tag.org2" }
+          }
+        },
+        {
+          "name": "markup.heading.6.org2",
+          "match": "^(\\*\\*\\*\\*\\*\\*)\\s+(?:(TODO)\\s+)?(.+?)(\\s+(:[^\\n:]+:)+)?$",
+          "captures": {
+            "1": { "name": "punctuation.definition.heading.org2" },
+            "2": { "name": "keyword.other.todo.org2" },
+            "3": { "name": "entity.name.section.org2" },
+            "4": { "name": "entity.other.attribute-name.tag.org2" }
+          }
+        },
+        {
           "name": "markup.heading.org2",
-          "match": "^(\\*+)\\s+(?:(TODO)\\s+)?(.+?)(\\s+(:[^\n:]+:)+)?$",
+          "match": "^(\\*{7,})\\s+(?:(TODO)\\s+)?(.+?)(\\s+(:[^\\n:]+:)+)?$",
           "captures": {
             "1": { "name": "punctuation.definition.heading.org2" },
             "2": { "name": "keyword.other.todo.org2" },


### PR DESCRIPTION
Adds a DocumentLinkProvider to make org-style links like [[url][desc]] and [[url]] clickable without changing the existing TextMate highlighting.

Improves the TextMate grammar to give distinct scopes to heading levels (markup.heading.1.org2 .. markup.heading.6.org2) so themes can style them differently.

Adds folding ranges for :PROPERTIES: drawers and auto-folds them once per document on open/activation (only for property drawers).

This PR was generated with AI assistance from openai-codex/gpt-5.2