### PR TITLE
vscode-org2: add UI for toggling TODO

### DIFF
--- a/editors/vscode-org2/README.md
+++ b/editors/vscode-org2/README.md
@@ -21,6 +21,17 @@ The extension attempts to render described links of the form `[[url][desc]]` so 
 
 Limitation: VS Code decorations cannot truly replace/collapse the underlying text width, so the original `[[url][desc]]` token is hidden (transparent) and `desc` is drawn as a prefix. This means the line still takes up the original character width even though you only see `desc`.
 
+## TODO status editing (MVP)
+
+The extension can toggle/set TODO keywords on the current headline via the `org2` CLI.
+
+- Command: **Org2: Toggle Todo Status** (`org2.toggleTodo`)
+- Command: **Org2: Set Todo Status** (`org2.setTodoStatus`)
+- Default keybinding: `ctrl+alt+t`
+- Also available in the editor right-click context menu.
+
+Implementation detail: the extension saves the file (if needed), runs `org2 todo toggle|set --file ... --line ... --apply`, then reverts the buffer to pick up the on-disk edits.
+
 ## Agenda (MVP)
 
 The extension can show an *agenda* view powered by the `org2` CLI.

--- a/editors/vscode-org2/package.json
+++ b/editors/vscode-org2/package.json
@@ -93,6 +93,18 @@
           "when": "view == org2Agenda",
           "group": "navigation"
         }
+      ],
+      "editor/context": [
+        {
+          "command": "org2.toggleTodo",
+          "when": "editorTextFocus && (editorLangId == 'org2' || editorLangId == 'org')",
+          "group": "navigation@10"
+        },
+        {
+          "command": "org2.setTodoStatus",
+          "when": "editorTextFocus && (editorLangId == 'org2' || editorLangId == 'org')",
+          "group": "navigation@11"
+        }
       ]
     },
     "configuration": {
@@ -149,12 +161,17 @@
       {
         "key": "ctrl+alt+o",
         "command": "org2.toggleFoldHere",
-        "when": "editorTextFocus && editorLangId == 'org2'"
+        "when": "editorTextFocus && (editorLangId == 'org2' || editorLangId == 'org')"
+      },
+      {
+        "key": "ctrl+alt+t",
+        "command": "org2.toggleTodo",
+        "when": "editorTextFocus && (editorLangId == 'org2' || editorLangId == 'org')"
       },
       {
         "key": "ctrl+alt+d",
         "command": "org2.debugFoldingRanges",
-        "when": "editorTextFocus && editorLangId == 'org2'"
+        "when": "editorTextFocus && (editorLangId == 'org2' || editorLangId == 'org')"
       }
     ]
   }


### PR DESCRIPTION
Adds editor context-menu entries and a default keybinding for toggling/setting TODO status in org2 files (delegates edits to the org2 CLI as before). Also broadens keybinding scope to work for both `org2` and `org` language ids and documents the feature in the README.

This PR was generated with AI assistance from gpt-5.2.