### PR TITLE
VSCode: set DEADLINE/SCHEDULED from agenda + editor

### DIFF
--- a/editors/vscode-org2/extension.js
+++ b/editors/vscode-org2/extension.js
@@ -671,25 +671,6 @@ function activate(context) {
     }
   }
 
-  function resolveAgendaItemPath(item) {
-    const agendaRoot = getAgendaRootDir();
-    const s = String(item && item.file ? item.file : '');
-    if (!s) return undefined;
-    return path.isAbsolute(s) ? s : path.resolve(agendaRoot, s);
-  }
-
-  function findOpenDocumentForPath(absPath) {
-    if (!absPath) return undefined;
-    const needle = path.resolve(absPath);
-    for (const d of vscode.workspace.textDocuments || []) {
-      if (d && d.uri && d.uri.scheme === 'file') {
-        const p = path.resolve(d.uri.fsPath);
-        if (p === needle) return d;
-      }
-    }
-    return undefined;
-  }
-
   async function runPlanCli(kind, item) {
     let filePath;
     let line;
@@ -788,8 +769,8 @@ function activate(context) {
   );
 
   context.subscriptions.push(
-    vscode.commands.registerCommand('org2.setDeadline', async () => {
-      await runPlanCli('deadline');
+    vscode.commands.registerCommand('org2.setDeadline', async (item) => {
+      await runPlanCli('deadline', item);
     })
   );
 

--- a/editors/vscode-org2/package.json
+++ b/editors/vscode-org2/package.json
@@ -21,13 +21,21 @@
   "engines": {
     "vscode": "^1.85.0"
   },
-  "categories": ["Programming Languages"],
+  "categories": [
+    "Programming Languages"
+  ],
   "contributes": {
     "languages": [
       {
         "id": "org2",
-        "aliases": ["Org2", "org2"],
-        "extensions": [".org", ".org2"],
+        "aliases": [
+          "Org2",
+          "org2"
+        ],
+        "extensions": [
+          ".org",
+          ".org2"
+        ],
         "configuration": "./language-configuration.json"
       }
     ],
@@ -120,6 +128,11 @@
           "command": "org2.toggleTodo",
           "when": "view == org2Agenda && viewItem == org2AgendaItem",
           "group": "navigation@11"
+        },
+        {
+          "command": "org2.setDeadline",
+          "when": "view == org2Agenda && viewItem == org2AgendaItem",
+          "group": "navigation@12"
         }
       ],
       "editor/context": [
@@ -132,6 +145,16 @@
           "command": "org2.setTodoStatus",
           "when": "editorTextFocus && (editorLangId == 'org2' || editorLangId == 'org')",
           "group": "navigation@11"
+        },
+        {
+          "command": "org2.setScheduled",
+          "when": "editorTextFocus && (editorLangId == 'org2' || editorLangId == 'org')",
+          "group": "navigation@12"
+        },
+        {
+          "command": "org2.setDeadline",
+          "when": "editorTextFocus && (editorLangId == 'org2' || editorLangId == 'org')",
+          "group": "navigation@13"
         }
       ]
     },
@@ -146,12 +169,17 @@
         "org2.agenda.args": {
           "type": "array",
           "default": [],
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Extra args prefixed when calling org2 (advanced; useful for 'node /path/to/dist/cli.js')."
         },
         "org2.agenda.scope": {
           "type": "string",
-          "enum": ["workspace", "files"],
+          "enum": [
+            "workspace",
+            "files"
+          ],
           "default": "workspace",
           "description": "Where to read org files from. 'workspace' scans org2.agenda.dir (or the workspace folder if unset); 'files' uses org2.agenda.files."
         },
@@ -163,7 +191,9 @@
         "org2.agenda.files": {
           "type": "array",
           "default": [],
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "List of org/org2 files (absolute or workspace-relative) to include when scope='files'."
         },
         "org2.agenda.days": {


### PR DESCRIPTION
Fixes #74

- Add Org2: Set SCHEDULED / Set DEADLINE to the editor context menu
- Add Org2: Set DEADLINE to the agenda item context menu
- Ensure setDeadline accepts an agenda item argument
- Remove a duplicate helper function definition in the extension

This PR was generated with AI assistance from gpt-5.2