### PR TITLE
VSCode: archive subtree

### DIFF
--- a/editors/vscode-org2/extension.js
+++ b/editors/vscode-org2/extension.js
@@ -740,6 +740,65 @@ function activate(context) {
     }
   }
 
+  async function runArchiveCli(item) {
+    let filePath;
+    let line;
+
+    if (item && item.file) {
+      filePath = resolveAgendaItemPath(item);
+      line = typeof item.line === 'number' ? item.line + 1 : 1;
+
+      const openDoc = findOpenDocumentForPath(filePath);
+      if (openDoc && openDoc.isDirty) {
+        vscode.window.showWarningMessage('Org2: please save the file before archiving from the agenda.');
+        return;
+      }
+    } else {
+      const editor = vscode.window.activeTextEditor;
+      if (!editor) return;
+
+      const doc = editor.document;
+      if (!doc || doc.uri.scheme !== 'file') {
+        vscode.window.showWarningMessage('Org2: archiving requires a file-backed document.');
+        return;
+      }
+
+      if (doc.isDirty) {
+        const ok = await doc.save();
+        if (!ok) {
+          vscode.window.showWarningMessage('Org2: could not save file before archiving.');
+          return;
+        }
+      }
+
+      filePath = doc.uri.fsPath;
+      line = editor.selection && editor.selection.active ? editor.selection.active.line + 1 : 1;
+    }
+
+    const ok = await vscode.window.showWarningMessage(
+      `Org2: archive subtree at line ${line}? (This will edit the file on disk)`,
+      { modal: true },
+      'Archive'
+    );
+    if (ok !== 'Archive') return;
+
+    const args = ['archive', '--file', String(filePath), '--pos', String(line), '--apply'];
+    const { cmd: finalCmd, args: finalArgs } = resolveOrg2Command(context, args);
+
+    try {
+      await execFileAsync(finalCmd, finalArgs, { cwd: getAgendaRootDir() });
+      await vscode.commands.executeCommand('workbench.action.files.revert');
+    } catch (e) {
+      vscode.window.showErrorMessage(`Org2: archive failed: ${String(e && e.message ? e.message : e)}`);
+    }
+  }
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('org2.archiveSubtree', async (item) => {
+      await runArchiveCli(item);
+    })
+  );
+
   context.subscriptions.push(
     vscode.commands.registerCommand('org2.toggleTodo', async (item) => {
       await runTodoCli('toggle', undefined, item);

--- a/editors/vscode-org2/package.json
+++ b/editors/vscode-org2/package.json
@@ -12,7 +12,8 @@
     "onCommand:org2.toggleTodo",
     "onCommand:org2.setTodoStatus",
     "onCommand:org2.setScheduled",
-    "onCommand:org2.setDeadline"
+    "onCommand:org2.setDeadline",
+    "onCommand:org2.archiveSubtree"
   ],
   "repository": {
     "type": "git",
@@ -85,6 +86,10 @@
         "title": "Org2: Set DEADLINE"
       },
       {
+        "command": "org2.archiveSubtree",
+        "title": "Org2: Archive Subtree"
+      },
+      {
         "command": "org2.toggleFoldHere",
         "title": "Org2: Toggle Fold Here"
       },
@@ -133,6 +138,11 @@
           "command": "org2.setDeadline",
           "when": "view == org2Agenda && viewItem == org2AgendaItem",
           "group": "navigation@12"
+        },
+        {
+          "command": "org2.archiveSubtree",
+          "when": "view == org2Agenda && viewItem == org2AgendaItem",
+          "group": "navigation@13"
         }
       ],
       "editor/context": [
@@ -155,6 +165,11 @@
           "command": "org2.setDeadline",
           "when": "editorTextFocus && (editorLangId == 'org2' || editorLangId == 'org')",
           "group": "navigation@13"
+        },
+        {
+          "command": "org2.archiveSubtree",
+          "when": "editorTextFocus && (editorLangId == 'org2' || editorLangId == 'org')",
+          "group": "navigation@14"
         }
       ]
     },


### PR DESCRIPTION
Adds an `Org2: Archive Subtree` command (editor + agenda item context menus) backed by `org2 archive --apply`.

This PR was generated with AI assistance from gpt-5.2.