### PR TITLE
tools: REST-based workaround for gh issue view

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -34,3 +34,14 @@ Notes:
   - every `spec/v0/tests/*.org` has a sibling `*.json` fixture (and vice versa)
   - each `*.json` conforms to `spec/v0/canonical-ast.schema.json`
 - With `--e2e` it also parses `.org` → AST using the reference parser and compares it to the sibling `*.json` (exact match).
+
+## GitHub issue view workaround
+
+`gh issue view` can fail for issues that reference GitHub Projects (classic). Use this REST-based workaround:
+
+```bash
+cd /path/to/org2
+node tools/gh-issue-view.mjs aviaviavi/org2#76
+# or
+node tools/gh-issue-view.mjs 76 --repo aviaviavi/org2
+```

--- a/tools/gh-issue-view.mjs
+++ b/tools/gh-issue-view.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * Workaround for `gh issue view` failing when an issue has Projects (classic).
+ * Uses the REST endpoint instead of GraphQL.
+ *
+ * Usage:
+ *   node tools/gh-issue-view.mjs 76 --repo aviaviavi/org2
+ *   node tools/gh-issue-view.mjs aviaviavi/org2#76
+ */
+
+import { execFileSync } from "node:child_process";
+
+function die(msg) {
+  console.error(msg);
+  process.exit(2);
+}
+
+const args = process.argv.slice(2);
+if (args.length === 0 || args.includes("-h") || args.includes("--help")) {
+  console.log(
+    [
+      "gh-issue-view.mjs",
+      "",
+      "Workaround for `gh issue view` failures caused by Projects (classic) deprecation.",
+      "",
+      "Usage:",
+      "  node tools/gh-issue-view.mjs 76 --repo aviaviavi/org2",
+      "  node tools/gh-issue-view.mjs aviaviavi/org2#76",
+    ].join("\n"),
+  );
+  process.exit(0);
+}
+
+let repo;
+let number;
+
+const first = args[0];
+const m = first.match(/^([^#]+)#(\d+)$/);
+if (m) {
+  repo = m[1];
+  number = m[2];
+} else {
+  number = first;
+}
+
+for (let i = 1; i < args.length; i++) {
+  if (args[i] === "--repo") repo = args[++i];
+}
+
+if (!number || !String(number).match(/^\d+$/)) die(`Invalid issue number: ${number}`);
+if (!repo) die("Missing --repo (or use owner/repo#number)");
+
+const jsonText = execFileSync(
+  "gh",
+  ["api", `repos/${repo}/issues/${number}`],
+  { encoding: "utf8" },
+);
+
+const issue = JSON.parse(jsonText);
+
+console.log(`#${issue.number} ${issue.title}`);
+console.log(issue.html_url);
+console.log("\n---\n");
+console.log(issue.body ?? "");


### PR DESCRIPTION
Adds tools/gh-issue-view.mjs (REST-based) + docs to avoid gh issue view GraphQL failure when issues reference GitHub Projects (classic).\n\nThis PR was generated with AI assistance from openai-codex/gpt-5.2.