### PR TITLE
VSCode: make auto-folding configurable

### DIFF
--- a/editors/vscode-org2/extension.js
+++ b/editors/vscode-org2/extension.js
@@ -7,12 +7,14 @@ const listItemRe = /^(\s*)(?:[-+*]|\d+[.)])\s+/;
 const propertiesBeginRe = /^\s*:PROPERTIES:\s*$/i;
 const drawerEndRe = /^\s*:END:\s*$/i;
 
-function findTopLevelHeadingLines(document) {
+function findHeadingLinesUpToLevel(document, maxLevel) {
+  if (typeof maxLevel !== 'number' || maxLevel <= 0) return [];
+
   const starts = [];
   for (let i = 0; i < document.lineCount; i++) {
     const text = document.lineAt(i).text;
     const m = headingRe.exec(text);
-    if (m && m[1].length === 1) starts.push(i);
+    if (m && m[1].length <= maxLevel) starts.push(i);
   }
   return starts;
 }
@@ -898,7 +900,14 @@ function activate(context) {
     const key = doc.uri.toString();
     if (autoFoldedForDoc.has(key)) return;
 
-    const startLines = [...findTopLevelHeadingLines(doc), ...findPropertyDrawerStartLines(doc)];
+    const cfg = vscode.workspace.getConfiguration('org2');
+    const maxLevel = cfg.get('folding.autoFoldMaxHeadingLevel', 1);
+    const foldPropertyDrawers = cfg.get('folding.autoFoldPropertyDrawers', true);
+
+    const startLines = [
+      ...findHeadingLinesUpToLevel(doc, maxLevel),
+      ...(foldPropertyDrawers ? findPropertyDrawerStartLines(doc) : []),
+    ];
 
     // Mark before folding to avoid repeated attempts on rapid focus changes.
     autoFoldedForDoc.add(key);

--- a/editors/vscode-org2/package.json
+++ b/editors/vscode-org2/package.json
@@ -227,6 +227,17 @@
           "type": "boolean",
           "default": true,
           "description": "Auto-format Org tables on save (runs `org2 fmt --stdin` and replaces the document)."
+        },
+        "org2.folding.autoFoldMaxHeadingLevel": {
+          "type": "number",
+          "default": 1,
+          "minimum": 0,
+          "description": "Auto-fold headings up to this level (1 = top-level only, 2 = fold level 1-2 headings, 0 = disable auto-folding headings)."
+        },
+        "org2.folding.autoFoldPropertyDrawers": {
+          "type": "boolean",
+          "default": true,
+          "description": "Auto-fold :PROPERTIES: drawers when a document is opened (once per file)."
         }
       }
     },


### PR DESCRIPTION
This PR was generated with AI assistance from openai-codex/gpt-5.2.

Adds VSCode extension settings:
- org2.folding.autoFoldMaxHeadingLevel (0=off; default 1)
- org2.folding.autoFoldPropertyDrawers (default true)

Updates auto-fold logic to respect these settings.