### PR TITLE
[codex] Add mobile share capture and macOS interaction fixes

### DIFF
--- a/apps/ios/Org2Mobile/Org2Mobile.xcodeproj/project.pbxproj
+++ b/apps/ios/Org2Mobile/Org2Mobile.xcodeproj/project.pbxproj
@@ -15,7 +15,35 @@
 		0A1001062C20000000000001 /* DocumentPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1002062C20000000000001 /* DocumentPicker.swift */; };
 		0A1001072C20000000000001 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0A1002072C20000000000001 /* Assets.xcassets */; };
 		0A1001082C20000000000001 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0A1002082C20000000000001 /* LaunchScreen.storyboard */; };
+		0A1001092C20000000000001 /* MobileCaptureSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1002092C20000000000001 /* MobileCaptureSupport.swift */; };
+		0A10010A2C20000000000001 /* MobileCaptureSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1002092C20000000000001 /* MobileCaptureSupport.swift */; };
+		0A10010B2C20000000000001 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A10020C2C20000000000001 /* ShareViewController.swift */; };
+		0A10010C2C20000000000001 /* Org2ShareExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 0A10020E2C20000000000001 /* Org2ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		0A100E012C20000000000001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0A100A012C20000000000001 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0A1006022C20000000000001;
+			remoteInfo = Org2ShareExtension;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		0A10090B2C20000000000001 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				0A10010C2C20000000000001 /* Org2ShareExtension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		0A1000012C20000000000001 /* Org2Mobile.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Org2Mobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -27,10 +55,23 @@
 		0A1002062C20000000000001 /* DocumentPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentPicker.swift; sourceTree = "<group>"; };
 		0A1002072C20000000000001 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		0A1002082C20000000000001 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		0A1002092C20000000000001 /* MobileCaptureSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileCaptureSupport.swift; sourceTree = "<group>"; };
+		0A10020A2C20000000000001 /* Org2Mobile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Org2Mobile.entitlements; sourceTree = "<group>"; };
+		0A10020B2C20000000000001 /* Org2ShareExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Org2ShareExtension.entitlements; sourceTree = "<group>"; };
+		0A10020C2C20000000000001 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
+		0A10020D2C20000000000001 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0A10020E2C20000000000001 /* Org2ShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = Org2ShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		0A1003012C20000000000001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0A1003022C20000000000001 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -44,6 +85,7 @@
 			isa = PBXGroup;
 			children = (
 				0A1005012C20000000000001 /* Org2Mobile */,
+				0A1005022C20000000000001 /* Org2ShareExtension */,
 				0A1004022C20000000000001 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -52,6 +94,7 @@
 			isa = PBXGroup;
 			children = (
 				0A1000012C20000000000001 /* Org2Mobile.app */,
+				0A10020E2C20000000000001 /* Org2ShareExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -62,13 +105,25 @@
 				0A1002012C20000000000001 /* Org2MobileApp.swift */,
 				0A1002022C20000000000001 /* ContentView.swift */,
 				0A1002032C20000000000001 /* Models.swift */,
+				0A1002092C20000000000001 /* MobileCaptureSupport.swift */,
 				0A1002042C20000000000001 /* OrgParser.swift */,
 				0A1002052C20000000000001 /* CorpusStore.swift */,
 				0A1002062C20000000000001 /* DocumentPicker.swift */,
 				0A1002082C20000000000001 /* LaunchScreen.storyboard */,
 				0A1002072C20000000000001 /* Assets.xcassets */,
+				0A10020A2C20000000000001 /* Org2Mobile.entitlements */,
 			);
 			path = Org2Mobile;
+			sourceTree = "<group>";
+		};
+		0A1005022C20000000000001 /* Org2ShareExtension */ = {
+			isa = PBXGroup;
+			children = (
+				0A10020C2C20000000000001 /* ShareViewController.swift */,
+				0A10020D2C20000000000001 /* Info.plist */,
+				0A10020B2C20000000000001 /* Org2ShareExtension.entitlements */,
+			);
+			path = Org2ShareExtension;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -81,15 +136,34 @@
 				0A1008012C20000000000001 /* Sources */,
 				0A1003012C20000000000001 /* Frameworks */,
 				0A1009012C20000000000001 /* Resources */,
+				0A10090B2C20000000000001 /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				0A100F012C20000000000001 /* PBXTargetDependency */,
 			);
 			name = Org2Mobile;
 			productName = Org2Mobile;
 			productReference = 0A1000012C20000000000001 /* Org2Mobile.app */;
 			productType = "com.apple.product-type.application";
+		};
+		0A1006022C20000000000001 /* Org2ShareExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0A1007022C20000000000001 /* Build configuration list for PBXNativeTarget "Org2ShareExtension" */;
+			buildPhases = (
+				0A1008022C20000000000001 /* Sources */,
+				0A1003022C20000000000001 /* Frameworks */,
+				0A10090A2C20000000000001 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Org2ShareExtension;
+			productName = Org2ShareExtension;
+			productReference = 0A10020E2C20000000000001 /* Org2ShareExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
 
@@ -102,6 +176,9 @@
 				LastUpgradeCheck = 1630;
 				TargetAttributes = {
 					0A1006012C20000000000001 = {
+						CreatedOnToolsVersion = 16.3;
+					};
+					0A1006022C20000000000001 = {
 						CreatedOnToolsVersion = 16.3;
 					};
 				};
@@ -121,6 +198,7 @@
 			projectRoot = "";
 			targets = (
 				0A1006012C20000000000001 /* Org2Mobile */,
+				0A1006022C20000000000001 /* Org2ShareExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -135,6 +213,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		0A10090A2C20000000000001 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -145,13 +230,31 @@
 				0A1001012C20000000000001 /* Org2MobileApp.swift in Sources */,
 				0A1001022C20000000000001 /* ContentView.swift in Sources */,
 				0A1001032C20000000000001 /* Models.swift in Sources */,
+				0A1001092C20000000000001 /* MobileCaptureSupport.swift in Sources */,
 				0A1001042C20000000000001 /* OrgParser.swift in Sources */,
 				0A1001052C20000000000001 /* CorpusStore.swift in Sources */,
 				0A1001062C20000000000001 /* DocumentPicker.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		0A1008022C20000000000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0A10010A2C20000000000001 /* MobileCaptureSupport.swift in Sources */,
+				0A10010B2C20000000000001 /* ShareViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		0A100F012C20000000000001 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0A1006022C20000000000001 /* Org2ShareExtension */;
+			targetProxy = 0A100E012C20000000000001 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		0A100C012C20000000000001 /* Debug */ = {
@@ -277,6 +380,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Org2Mobile/Org2Mobile.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 9MW3N969TR;
@@ -312,6 +416,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Org2Mobile/Org2Mobile.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 9MW3N969TR;
@@ -343,6 +448,64 @@
 			};
 			name = Release;
 		};
+		0A100D032C20000000000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_ENTITLEMENTS = Org2ShareExtension/Org2ShareExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 9MW3N969TR;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Org2ShareExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = org.org2.mobile.ShareExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		0A100D042C20000000000001 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_ENTITLEMENTS = Org2ShareExtension/Org2ShareExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 9MW3N969TR;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Org2ShareExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = org.org2.mobile.ShareExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -351,6 +514,15 @@
 			buildConfigurations = (
 				0A100D012C20000000000001 /* Debug */,
 				0A100D022C20000000000001 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0A1007022C20000000000001 /* Build configuration list for PBXNativeTarget "Org2ShareExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0A100D032C20000000000001 /* Debug */,
+				0A100D042C20000000000001 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/apps/ios/Org2Mobile/Org2Mobile/ContentView.swift
+++ b/apps/ios/Org2Mobile/Org2Mobile/ContentView.swift
@@ -549,6 +549,8 @@ private struct NewNoteView: View {
   @EnvironmentObject private var store: CorpusStore
   @State private var title = ""
   @State private var bodyText = ""
+  @State private var schedule: MobileNoteSchedule = .none
+  @State private var customScheduledDate = Date()
   @State private var attachments: [NoteAttachment] = []
   @State private var isPhotoLibraryPresented = false
   @State private var isCameraPresented = false
@@ -585,6 +587,40 @@ private struct NewNoteView: View {
           TextEditor(text: $bodyText)
             .frame(minHeight: 120)
             .focused($focusedField, equals: .body)
+
+          VStack(alignment: .leading, spacing: 10) {
+            Text("Schedule TODO")
+              .font(.caption.weight(.semibold))
+              .foregroundStyle(.secondary)
+
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 132), spacing: 8)], alignment: .leading, spacing: 8) {
+              ForEach(MobileNoteSchedule.allCases) { option in
+                Button {
+                  schedule = option
+                } label: {
+                  Label(option.title, systemImage: option.systemImage)
+                    .lineLimit(1)
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .tint(schedule == option ? .accentColor : .secondary)
+              }
+            }
+
+            if schedule == .custom {
+              DatePicker(
+                "Date",
+                selection: $customScheduledDate,
+                displayedComponents: .date
+              )
+            } else if let date = scheduledDate {
+              Label(MobileCaptureWriter.orgDayTimestamp(date), systemImage: "calendar")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+          }
+          .padding(.vertical, 4)
 
           if !attachments.isEmpty {
             ForEach(attachments) { attachment in
@@ -623,9 +659,16 @@ private struct NewNoteView: View {
 
           Button {
             Task {
-              await store.saveMobileNote(title: title, body: bodyText, attachments: attachments)
+              await store.saveMobileNote(
+                title: title,
+                body: bodyText,
+                attachments: attachments,
+                scheduledDate: scheduledDate
+              )
               title = ""
               bodyText = ""
+              schedule = .none
+              customScheduledDate = Date()
               attachments = []
               focusedField = nil
             }
@@ -682,6 +725,10 @@ private struct NewNoteView: View {
     let imageData = UIImage(data: data)?.jpegData(compressionQuality: 0.86) ?? data
     let filename = "photo-\(UUID().uuidString.prefix(8)).jpg"
     attachments.append(NoteAttachment(filename: filename, data: imageData))
+  }
+
+  private var scheduledDate: Date? {
+    schedule.scheduledDate(customDate: customScheduledDate)
   }
 }
 

--- a/apps/ios/Org2Mobile/Org2Mobile/CorpusStore.swift
+++ b/apps/ios/Org2Mobile/Org2Mobile/CorpusStore.swift
@@ -13,10 +13,10 @@ final class CorpusStore: ObservableObject {
   @Published var statusMessage: String?
   @Published var isDocumentPickerPresented = false
 
-  private let bookmarkKey = "org2.mobile.corpusBookmark"
-  private let cachedRootPathKey = "org2.mobile.cachedRootPath"
-  private let mobileInboxFilename = "mobile-inbox.org2"
-  private let mobileInboxAssetsDirectory = "mobile-inbox-assets"
+  private let bookmarkKey = MobileCaptureWriter.bookmarkKey
+  private let cachedRootPathKey = MobileCaptureWriter.cachedRootPathKey
+  private let mobileInboxFilename = MobileCaptureWriter.mobileInboxFilename
+  private let mobileInboxAssetsDirectory = MobileCaptureWriter.mobileInboxAssetsDirectory
   private let cacheFilename = "org2-mobile-corpus-cache.json"
   private let headingTodoKeywords = Set(OrgTodoStatus.allCases.map(\.rawValue))
   private var cachedFileCount: Int?
@@ -62,7 +62,7 @@ final class CorpusStore: ObservableObject {
       statusMessage = "Corpus ready"
     }
 
-    guard let data = UserDefaults.standard.data(forKey: bookmarkKey) else { return }
+    guard let data = UserDefaults.standard.data(forKey: bookmarkKey) ?? MobileCaptureWriter.sharedDefaults.data(forKey: bookmarkKey) else { return }
     restoreBookmarkedCorpus(data)
   }
 
@@ -197,10 +197,10 @@ final class CorpusStore: ObservableObject {
     }
   }
 
-  func saveMobileNote(title: String, body: String, attachments: [NoteAttachment] = []) async {
+  func saveMobileNote(title: String, body: String, attachments: [NoteAttachment] = [], scheduledDate: Date? = nil) async {
     guard rootURL != nil else { return }
     do {
-      let inboxURL = try appendMobileNote(title: title, body: body, attachments: attachments)
+      let inboxURL = try appendMobileNote(title: title, body: body, attachments: attachments, scheduledDate: scheduledDate)
       statusMessage = "Queued note in \(inboxURL.lastPathComponent)"
     } catch {
       errorMessage = "Could not write to corpus mobile-inbox.org2. Re-select the synced corpus folder and try again."
@@ -303,6 +303,7 @@ final class CorpusStore: ObservableObject {
       let data = try JSONEncoder().encode(cacheSnapshot)
       try data.write(to: cacheURL, options: .atomic)
       UserDefaults.standard.set(cacheSnapshot.rootPath, forKey: cachedRootPathKey)
+      MobileCaptureWriter.sharedDefaults.set(cacheSnapshot.rootPath, forKey: cachedRootPathKey)
     } catch {
       // Cache writes should never block the live corpus view.
     }
@@ -311,6 +312,7 @@ final class CorpusStore: ObservableObject {
   private func setRootURL(_ url: URL) {
     rootURL = url
     UserDefaults.standard.set(Self.cacheRootPath(for: url), forKey: cachedRootPathKey)
+    MobileCaptureWriter.sharedDefaults.set(Self.cacheRootPath(for: url), forKey: cachedRootPathKey)
   }
 
   nonisolated private static func cacheRootPath(for rootURL: URL) -> String {
@@ -532,57 +534,17 @@ final class CorpusStore: ObservableObject {
     try appendMobileInbox(content, attachments: attachments, entryID: entryID, baseURL: try preferredCorpusBaseURL(for: rootURL))
   }
 
-  private func appendMobileNote(title: String, body: String, attachments: [NoteAttachment]) throws -> URL {
+  private func appendMobileNote(title: String, body: String, attachments: [NoteAttachment], scheduledDate: Date?) throws -> URL {
     guard let rootURL else {
       throw CocoaError(.fileNoSuchFile)
     }
-
-    let hasSecurityAccess = rootURL.startAccessingSecurityScopedResource()
-    defer {
-      if hasSecurityAccess {
-        rootURL.stopAccessingSecurityScopedResource()
-      }
-    }
-
-    let baseURL = try preferredCorpusBaseURL(for: rootURL)
-    let createdAt = ISO8601DateFormatter().string(from: Date())
-    let fileStamp = createdAt
-      .replacingOccurrences(of: ":", with: "")
-      .replacingOccurrences(of: "-", with: "")
-      .replacingOccurrences(of: ".", with: "")
-    let entryID = "\(fileStamp)-note-\(UUID().uuidString.prefix(8))"
-    let sanitizedTitle = sanitizeProperty(title)
-    let noteTitle = sanitizedTitle.isEmpty ? "Phone note" : sanitizedTitle
-    let bodyText = body.trimmingCharacters(in: .whitespacesAndNewlines)
-    let attachmentLinks = attachments
-      .map { "- [[file:\(mobileInboxAssetsDirectory)/\(entryID)/\($0.filename)][\($0.filename)]]" }
-      .joined(separator: "\n")
-    let bodySection = bodyText.isEmpty ? "" : """
-
-    \(bodyText)
-    """
-    let attachmentsSection = attachmentLinks.isEmpty ? "" : """
-
-    Attachments:
-    \(attachmentLinks)
-    """
-
-    let content = """
-
-    * \(noteTitle)
-    :PROPERTIES:
-    :ID: mobile-\(entryID)
-    :KIND: mobile-note
-    :STATUS: pending
-    :DAILY_DATE: \(Date.org2TodayString)
-    :CREATED_AT: \(createdAt)
-    :SOURCE: org2-mobile
-    :END:
-    \(bodySection)\(attachmentsSection)
-    """
-
-    try appendMobileInbox(content, attachments: attachments, entryID: entryID, baseURL: baseURL)
-    return baseURL.appending(path: mobileInboxFilename)
+    return try MobileCaptureWriter.appendMobileNote(
+      rootURL: rootURL,
+      title: title,
+      body: body,
+      attachments: attachments,
+      scheduledDate: scheduledDate
+    )
   }
 
   private func approveInCorpus(_ approval: ApprovalEntry) throws -> URL {
@@ -714,6 +676,7 @@ final class CorpusStore: ObservableObject {
   private func saveBookmark(for url: URL) throws {
     let data = try Self.bookmarkData(for: url)
     UserDefaults.standard.set(data, forKey: bookmarkKey)
+    MobileCaptureWriter.saveSharedCorpusAccess(bookmark: data, rootURL: url)
     UserDefaults.standard.synchronize()
   }
 

--- a/apps/ios/Org2Mobile/Org2Mobile/MobileCaptureSupport.swift
+++ b/apps/ios/Org2Mobile/Org2Mobile/MobileCaptureSupport.swift
@@ -1,0 +1,235 @@
+import Foundation
+
+enum MobileNoteSchedule: String, CaseIterable, Identifiable {
+  case none
+  case today
+  case tomorrow
+  case nextWeek
+  case nextMonth
+  case custom
+
+  var id: String { rawValue }
+
+  var title: String {
+    switch self {
+    case .none: "No Schedule"
+    case .today: "Today"
+    case .tomorrow: "Tomorrow"
+    case .nextWeek: "Next Week"
+    case .nextMonth: "Next Month"
+    case .custom: "Pick Date"
+    }
+  }
+
+  var systemImage: String {
+    switch self {
+    case .none: "calendar.badge.minus"
+    case .today: "calendar"
+    case .tomorrow: "calendar.badge.clock"
+    case .nextWeek: "calendar.badge.plus"
+    case .nextMonth: "calendar.circle"
+    case .custom: "calendar.badge.plus"
+    }
+  }
+
+  func scheduledDate(customDate: Date, calendar: Calendar = .current) -> Date? {
+    let today = calendar.startOfDay(for: Date())
+    switch self {
+    case .none:
+      return nil
+    case .today:
+      return today
+    case .tomorrow:
+      return calendar.date(byAdding: .day, value: 1, to: today)
+    case .nextWeek:
+      return calendar.date(byAdding: .weekOfYear, value: 1, to: today)
+    case .nextMonth:
+      return calendar.date(byAdding: .month, value: 1, to: today)
+    case .custom:
+      return calendar.startOfDay(for: customDate)
+    }
+  }
+}
+
+struct NoteAttachment: Identifiable, Hashable {
+  let id = UUID()
+  let filename: String
+  let data: Data
+}
+
+enum MobileCaptureWriter {
+  static let appGroupID = "group.org.org2.mobile"
+  static let bookmarkKey = "org2.mobile.corpusBookmark"
+  static let cachedRootPathKey = "org2.mobile.cachedRootPath"
+  static let mobileInboxFilename = "mobile-inbox.org2"
+  static let mobileInboxAssetsDirectory = "mobile-inbox-assets"
+
+  static var sharedDefaults: UserDefaults {
+    UserDefaults(suiteName: appGroupID) ?? .standard
+  }
+
+  static func saveSharedCorpusAccess(bookmark: Data, rootURL: URL) {
+    sharedDefaults.set(bookmark, forKey: bookmarkKey)
+    sharedDefaults.set(cacheRootPath(for: rootURL), forKey: cachedRootPathKey)
+    sharedDefaults.synchronize()
+  }
+
+  static func resolveSharedCorpusRoot() throws -> URL? {
+    guard let data = sharedDefaults.data(forKey: bookmarkKey) else { return nil }
+    var stale = false
+    do {
+      return try URL(
+        resolvingBookmarkData: data,
+        options: [.withoutUI],
+        relativeTo: nil,
+        bookmarkDataIsStale: &stale
+      )
+    } catch {
+      stale = true
+      return try URL(
+        resolvingBookmarkData: data,
+        options: [],
+        relativeTo: nil,
+        bookmarkDataIsStale: &stale
+      )
+    }
+  }
+
+  static func appendMobileNote(
+    rootURL: URL,
+    title: String,
+    body: String,
+    attachments: [NoteAttachment] = [],
+    scheduledDate: Date? = nil
+  ) throws -> URL {
+    let hasSecurityAccess = rootURL.startAccessingSecurityScopedResource()
+    defer {
+      if hasSecurityAccess {
+        rootURL.stopAccessingSecurityScopedResource()
+      }
+    }
+
+    let baseURL = try preferredCorpusBaseURL(for: rootURL)
+    let createdAt = ISO8601DateFormatter().string(from: Date())
+    let fileStamp = createdAt
+      .replacingOccurrences(of: ":", with: "")
+      .replacingOccurrences(of: "-", with: "")
+      .replacingOccurrences(of: ".", with: "")
+    let entryID = "\(fileStamp)-note-\(UUID().uuidString.prefix(8))"
+    let sanitizedTitle = sanitizeProperty(title)
+    let noteTitle = sanitizedTitle.isEmpty ? "Phone note" : sanitizedTitle
+    let bodyText = body.trimmingCharacters(in: .whitespacesAndNewlines)
+    let attachmentLinks = attachments
+      .map { "- [[file:\(mobileInboxAssetsDirectory)/\(entryID)/\($0.filename)][\($0.filename)]]" }
+      .joined(separator: "\n")
+    let planningLine = scheduledDate.map { "SCHEDULED: \(orgDayTimestamp($0))\n" } ?? ""
+    let headingPrefix = scheduledDate == nil ? "*" : "* TODO"
+    let bodySection = bodyText.isEmpty ? "" : """
+
+    \(bodyText)
+    """
+    let attachmentsSection = attachmentLinks.isEmpty ? "" : """
+
+    Attachments:
+    \(attachmentLinks)
+    """
+
+    let content = """
+
+    \(headingPrefix) \(noteTitle)
+    \(planningLine):PROPERTIES:
+    :ID: mobile-\(entryID)
+    :KIND: mobile-note
+    :STATUS: pending
+    :DAILY_DATE: \(orgDayString(Date()))
+    :CREATED_AT: \(createdAt)
+    :SOURCE: org2-mobile
+    :END:
+    \(bodySection)\(attachmentsSection)
+    """
+
+    return try appendMobileInbox(content, attachments: attachments, entryID: entryID, baseURL: baseURL)
+  }
+
+  static func appendMobileInbox(
+    _ content: String,
+    attachments: [NoteAttachment],
+    entryID: String,
+    baseURL: URL
+  ) throws -> URL {
+    let inboxURL = baseURL.appendingPathComponent(mobileInboxFilename)
+    if !attachments.isEmpty {
+      let assetsURL = baseURL
+        .appendingPathComponent(mobileInboxAssetsDirectory, isDirectory: true)
+        .appendingPathComponent(entryID, isDirectory: true)
+      try FileManager.default.createDirectory(at: assetsURL, withIntermediateDirectories: true)
+      for attachment in attachments {
+        try attachment.data.write(to: assetsURL.appendingPathComponent(attachment.filename), options: .atomic)
+      }
+    }
+
+    if !FileManager.default.fileExists(atPath: inboxURL.path) {
+      let header = """
+      #+TITLE: Org2 Mobile Inbox
+
+      """
+      try header.write(to: inboxURL, atomically: true, encoding: .utf8)
+    }
+
+    let handle = try FileHandle(forWritingTo: inboxURL)
+    defer {
+      try? handle.close()
+    }
+    try handle.seekToEnd()
+    if let data = content.data(using: .utf8) {
+      try handle.write(contentsOf: data)
+    }
+    return inboxURL
+  }
+
+  static func orgDayString(_ date: Date) -> String {
+    orgDayFormatter.string(from: date)
+  }
+
+  static func orgDayTimestamp(_ date: Date) -> String {
+    "<\(orgPlanningDayFormatter.string(from: date))>"
+  }
+
+  private static func preferredCorpusBaseURL(for rootURL: URL) throws -> URL {
+    try isRegularFile(rootURL) ? rootURL.deletingLastPathComponent() : rootURL
+  }
+
+  private static func isRegularFile(_ url: URL) throws -> Bool {
+    let values = try url.resourceValues(forKeys: [.isRegularFileKey])
+    return values.isRegularFile == true
+  }
+
+  private static func cacheRootPath(for rootURL: URL) -> String {
+    rootURL.standardizedFileURL.path
+  }
+
+  private static func sanitizeProperty(_ value: String) -> String {
+    value
+      .replacingOccurrences(of: "\n", with: " ")
+      .replacingOccurrences(of: "\r", with: " ")
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  private static let orgDayFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.calendar = Calendar(identifier: .gregorian)
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = .current
+    formatter.dateFormat = "yyyy-MM-dd"
+    return formatter
+  }()
+
+  private static let orgPlanningDayFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.calendar = Calendar(identifier: .gregorian)
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = .current
+    formatter.dateFormat = "yyyy-MM-dd EEE"
+    return formatter
+  }()
+}

--- a/apps/ios/Org2Mobile/Org2Mobile/Models.swift
+++ b/apps/ios/Org2Mobile/Org2Mobile/Models.swift
@@ -116,12 +116,6 @@ struct ApprovalEntry: Identifiable, Hashable, Codable {
   }
 }
 
-struct NoteAttachment: Identifiable, Hashable {
-  let id = UUID()
-  let filename: String
-  let data: Data
-}
-
 enum OpenClawAction: String {
   case discuss
 
@@ -181,7 +175,7 @@ extension String {
 
 extension Date {
   static var org2TodayString: String {
-    org2DayFormatter.string(from: Date())
+    MobileCaptureWriter.orgDayString(Date())
   }
 
   static let org2DayFormatter: DateFormatter = {

--- a/apps/ios/Org2Mobile/Org2Mobile/Org2Mobile.entitlements
+++ b/apps/ios/Org2Mobile/Org2Mobile/Org2Mobile.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.org.org2.mobile</string>
+	</array>
+</dict>
+</plist>

--- a/apps/ios/Org2Mobile/Org2ShareExtension/Info.plist
+++ b/apps/ios/Org2Mobile/Org2ShareExtension/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Capture to Org2</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<dict>
+				<key>NSExtensionActivationSupportsFileWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsText</key>
+				<true/>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsWebPageWithMaxCount</key>
+				<integer>1</integer>
+			</dict>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).ShareViewController</string>
+	</dict>
+</dict>
+</plist>

--- a/apps/ios/Org2Mobile/Org2ShareExtension/Org2ShareExtension.entitlements
+++ b/apps/ios/Org2Mobile/Org2ShareExtension/Org2ShareExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.org.org2.mobile</string>
+	</array>
+</dict>
+</plist>

--- a/apps/ios/Org2Mobile/Org2ShareExtension/ShareViewController.swift
+++ b/apps/ios/Org2Mobile/Org2ShareExtension/ShareViewController.swift
@@ -1,0 +1,287 @@
+import SwiftUI
+import UIKit
+import UniformTypeIdentifiers
+
+final class ShareViewController: UIViewController {
+  private var host: UIHostingController<ShareCaptureView>?
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    embed(title: "", body: "", isLoading: true, errorMessage: nil)
+    loadSharedContent()
+  }
+
+  private func embed(title: String, body: String, isLoading: Bool, errorMessage: String?) {
+    let view = ShareCaptureView(
+      initialTitle: title,
+      initialBody: body,
+      isLoading: isLoading,
+      initialErrorMessage: errorMessage,
+      onCancel: { [weak self] in
+        self?.extensionContext?.cancelRequest(withError: CocoaError(.userCancelled))
+      },
+      onSave: { [weak self] title, body, scheduledDate in
+        self?.save(title: title, body: body, scheduledDate: scheduledDate)
+      }
+    )
+
+    let host = UIHostingController(rootView: view)
+    addChild(host)
+    self.view.addSubview(host.view)
+    host.view.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      host.view.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+      host.view.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+      host.view.topAnchor.constraint(equalTo: self.view.topAnchor),
+      host.view.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+    ])
+    host.didMove(toParent: self)
+
+    self.host?.willMove(toParent: nil)
+    self.host?.view.removeFromSuperview()
+    self.host?.removeFromParent()
+    self.host = host
+  }
+
+  private func loadSharedContent() {
+    let attachments = extensionContext?.inputItems
+      .compactMap { $0 as? NSExtensionItem }
+      .flatMap { $0.attachments ?? [] } ?? []
+
+    guard !attachments.isEmpty else {
+      embed(title: "", body: "", isLoading: false, errorMessage: nil)
+      return
+    }
+
+    let group = DispatchGroup()
+    let accumulator = ShareLoadAccumulator()
+
+    for provider in attachments {
+      if provider.hasItemConformingToTypeIdentifier(UTType.url.identifier) {
+        group.enter()
+        provider.loadItem(forTypeIdentifier: UTType.url.identifier, options: nil) { item, _ in
+          if let url = Self.url(from: item) {
+            accumulator.append(url: url)
+          }
+          group.leave()
+        }
+      }
+
+      if provider.hasItemConformingToTypeIdentifier(UTType.plainText.identifier) {
+        group.enter()
+        provider.loadItem(forTypeIdentifier: UTType.plainText.identifier, options: nil) { item, _ in
+          if let text = Self.text(from: item) {
+            accumulator.append(text: text)
+          }
+          group.leave()
+        }
+      }
+    }
+
+    group.notify(queue: .main) {
+      let texts = accumulator.texts
+      let urls = accumulator.urls
+      let title = Self.defaultTitle(texts: texts, urls: urls)
+      let body = Self.defaultBody(texts: texts, urls: urls)
+      self.embed(title: title, body: body, isLoading: false, errorMessage: nil)
+    }
+  }
+
+  private func save(title: String, body: String, scheduledDate: Date?) {
+    do {
+      guard let rootURL = try MobileCaptureWriter.resolveSharedCorpusRoot() else {
+        embed(
+          title: title,
+          body: body,
+          isLoading: false,
+          errorMessage: "Open Org2 and select a corpus folder before using the share extension."
+        )
+        return
+      }
+
+      _ = try MobileCaptureWriter.appendMobileNote(
+        rootURL: rootURL,
+        title: title,
+        body: body,
+        scheduledDate: scheduledDate
+      )
+      extensionContext?.completeRequest(returningItems: nil)
+    } catch {
+      embed(
+        title: title,
+        body: body,
+        isLoading: false,
+        errorMessage: "Could not capture this item. Re-select the corpus folder in Org2 and try again."
+      )
+    }
+  }
+
+  nonisolated private static func url(from item: Any?) -> URL? {
+    if let url = item as? URL { return url }
+    if let url = item as? NSURL { return url as URL }
+    if let string = item as? String { return URL(string: string) }
+    return nil
+  }
+
+  nonisolated private static func text(from item: Any?) -> String? {
+    if let text = item as? String { return text }
+    if let data = item as? Data { return String(data: data, encoding: .utf8) }
+    if let url = item as? URL { return url.absoluteString }
+    return nil
+  }
+
+  private static func defaultTitle(texts: [String], urls: [URL]) -> String {
+    if let firstLine = texts
+      .flatMap({ $0.components(separatedBy: .newlines) })
+      .map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) })
+      .first(where: { !$0.isEmpty }) {
+      return String(firstLine.prefix(90))
+    }
+    if let url = urls.first {
+      return url.host(percentEncoded: false) ?? url.absoluteString
+    }
+    return "Shared item"
+  }
+
+  private static func defaultBody(texts: [String], urls: [URL]) -> String {
+    var parts = texts
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { !$0.isEmpty }
+    parts.append(contentsOf: urls.map(\.absoluteString))
+    let uniqueParts = Array(NSOrderedSet(array: parts)) as? [String] ?? parts
+    return uniqueParts.joined(separator: "\n\n")
+  }
+}
+
+private final class ShareLoadAccumulator: @unchecked Sendable {
+  private let lock = NSLock()
+  private var loadedTexts: [String] = []
+  private var loadedURLs: [URL] = []
+
+  var texts: [String] {
+    lock.lock()
+    defer { lock.unlock() }
+    return loadedTexts
+  }
+
+  var urls: [URL] {
+    lock.lock()
+    defer { lock.unlock() }
+    return loadedURLs
+  }
+
+  func append(text: String) {
+    lock.lock()
+    loadedTexts.append(text)
+    lock.unlock()
+  }
+
+  func append(url: URL) {
+    lock.lock()
+    loadedURLs.append(url)
+    lock.unlock()
+  }
+}
+
+private struct ShareCaptureView: View {
+  @State private var title: String
+  @State private var bodyText: String
+  @State private var schedule: MobileNoteSchedule = .none
+  @State private var customScheduledDate = Date()
+  @State private var isSaving = false
+  @State private var errorMessage: String?
+  let isLoading: Bool
+  let onCancel: () -> Void
+  let onSave: (String, String, Date?) -> Void
+
+  init(
+    initialTitle: String,
+    initialBody: String,
+    isLoading: Bool,
+    initialErrorMessage: String?,
+    onCancel: @escaping () -> Void,
+    onSave: @escaping (String, String, Date?) -> Void
+  ) {
+    _title = State(initialValue: initialTitle)
+    _bodyText = State(initialValue: initialBody)
+    _errorMessage = State(initialValue: initialErrorMessage)
+    self.isLoading = isLoading
+    self.onCancel = onCancel
+    self.onSave = onSave
+  }
+
+  var body: some View {
+    NavigationStack {
+      List {
+        if isLoading {
+          Section {
+            HStack(spacing: 10) {
+              ProgressView()
+              Text("Loading shared item")
+            }
+          }
+        } else {
+          if let errorMessage {
+            Section {
+              Text(errorMessage)
+                .foregroundStyle(.red)
+            }
+          }
+
+          Section("Capture") {
+            TextField("Title", text: $title)
+            TextEditor(text: $bodyText)
+              .frame(minHeight: 120)
+          }
+
+          Section("Schedule TODO") {
+            ForEach(MobileNoteSchedule.allCases) { option in
+              Button {
+                schedule = option
+              } label: {
+                Label(option.title, systemImage: schedule == option ? "checkmark.circle.fill" : option.systemImage)
+              }
+            }
+
+            if schedule == .custom {
+              DatePicker("Date", selection: $customScheduledDate, displayedComponents: .date)
+            } else if let scheduledDate {
+              Label(MobileCaptureWriter.orgDayTimestamp(scheduledDate), systemImage: "calendar")
+                .foregroundStyle(.secondary)
+            }
+          }
+        }
+      }
+      .navigationTitle("Capture to Org2")
+      .navigationBarTitleDisplayMode(.inline)
+      .toolbar {
+        ToolbarItem(placement: .cancellationAction) {
+          Button("Cancel", action: onCancel)
+            .disabled(isSaving)
+        }
+        ToolbarItem(placement: .confirmationAction) {
+          Button {
+            isSaving = true
+            onSave(title, bodyText, scheduledDate)
+          } label: {
+            if isSaving {
+              ProgressView()
+            } else {
+              Text("Save")
+            }
+          }
+          .disabled(isLoading || isSaving || !canSave)
+        }
+      }
+    }
+  }
+
+  private var scheduledDate: Date? {
+    schedule.scheduledDate(customDate: customScheduledDate)
+  }
+
+  private var canSave: Bool {
+    !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      || !bodyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+  }
+}

--- a/apps/ios/Org2Mobile/README.md
+++ b/apps/ios/Org2Mobile/README.md
@@ -6,6 +6,8 @@ This is a bare-minimum iOS SwiftUI app for phone-side Org2 review:
 - shows scheduled/deadline TODOs in a basic agenda;
 - finds `ORG2_REVIEW_STATUS: review-required` and similar approval candidates;
 - queues new notes in `mobile-inbox.org2` so desktop sync can merge/refile them safely;
+- lets new notes become scheduled TODOs with Today, Tomorrow, Next Week, Next Month, or a picked date;
+- installs a Share extension named "Capture to Org2" for OS-level capture from apps such as X;
 - appends approval/discussion actions to `mobile-inbox.org2` in the selected corpus;
 - opens a WhatsApp share URL for approval discussion fallback.
 
@@ -22,3 +24,5 @@ Recommended first setup:
 5. Refile mobile notes into daily files after sync has settled.
 
 Tailscale can help devices see each other, but iOS does not provide reliable always-on Syncthing-style background daemon behavior. Treat phone sync as opportunistic: open the sync app before reviewing if the corpus has to be current.
+
+The app and share extension use the `group.org.org2.mobile` app group so the extension can reuse the selected corpus bookmark. Enable that App Group for both targets in the Apple developer portal before device signing.

--- a/apps/macos/Org2Workspace/Sources/Org2WorkspaceCore/OpenClawChatViews.swift
+++ b/apps/macos/Org2Workspace/Sources/Org2WorkspaceCore/OpenClawChatViews.swift
@@ -308,7 +308,7 @@ private struct OpenClawChangeDeltaView: View {
 struct OpenClawComposerView: View {
   @EnvironmentObject private var store: WorkspaceStore
   @State private var localDraft = ""
-  @State private var draftSyncTask: Task<Void, Never>?
+  @State private var lastStoreDraft = ""
   let focusOnAppear: Bool
   let compact: Bool
 
@@ -398,6 +398,7 @@ struct OpenClawComposerView: View {
         .help("Attach image")
 
         Button {
+          flushDraftToStore()
           Task { await store.toggleOpenClawVoiceNoteRecording() }
         } label: {
           Label(
@@ -420,17 +421,20 @@ struct OpenClawComposerView: View {
     }
     .onAppear {
       localDraft = store.openClawDraft
+      lastStoreDraft = store.openClawDraft
     }
     .onDisappear {
       flushDraftToStore()
     }
-    .onChange(of: localDraft) {
-      scheduleDraftSync()
-    }
     .onChange(of: store.openClawDraft) { _, newValue in
-      guard newValue != localDraft else { return }
-      draftSyncTask?.cancel()
-      localDraft = newValue
+      let mergedDraft = OpenClawComposerDraftSync.localDraftAfterStoreChange(
+        localDraft: localDraft,
+        previousStoreDraft: lastStoreDraft,
+        nextStoreDraft: newValue
+      )
+      lastStoreDraft = newValue
+      guard mergedDraft != localDraft else { return }
+      localDraft = mergedDraft
     }
   }
 
@@ -442,8 +446,8 @@ struct OpenClawComposerView: View {
   private func sendIfPossible() -> Bool {
     guard canSend else { return false }
     let text = localDraft
-    draftSyncTask?.cancel()
     localDraft = ""
+    lastStoreDraft = ""
     store.openClawDraft = ""
     Task { await store.sendComposedOpenClawMessage(text: text) }
     return true
@@ -454,23 +458,39 @@ struct OpenClawComposerView: View {
     return true
   }
 
-  private func scheduleDraftSync() {
-    draftSyncTask?.cancel()
-    let draft = localDraft
-    draftSyncTask = Task { @MainActor in
-      try? await Task.sleep(nanoseconds: 180_000_000)
-      guard !Task.isCancelled else { return }
-      if store.openClawDraft != draft {
-        store.openClawDraft = draft
-      }
+  private func flushDraftToStore() {
+    if store.openClawDraft != localDraft {
+      lastStoreDraft = localDraft
+      store.openClawDraft = localDraft
+    } else {
+      lastStoreDraft = store.openClawDraft
     }
   }
+}
 
-  private func flushDraftToStore() {
-    draftSyncTask?.cancel()
-    if store.openClawDraft != localDraft {
-      store.openClawDraft = localDraft
+enum OpenClawComposerDraftSync {
+  static func localDraftAfterStoreChange(
+    localDraft: String,
+    previousStoreDraft: String,
+    nextStoreDraft: String
+  ) -> String {
+    guard nextStoreDraft != localDraft else { return localDraft }
+    guard localDraft != previousStoreDraft else { return nextStoreDraft }
+    guard !nextStoreDraft.isEmpty else { return "" }
+    guard !localDraft.isEmpty else { return nextStoreDraft }
+
+    if nextStoreDraft.contains(localDraft) {
+      return nextStoreDraft
     }
+
+    if !previousStoreDraft.isEmpty,
+       let range = nextStoreDraft.range(of: previousStoreDraft) {
+      var merged = nextStoreDraft
+      merged.replaceSubrange(range, with: localDraft)
+      return merged
+    }
+
+    return nextStoreDraft + localDraft
   }
 }
 

--- a/apps/macos/Org2Workspace/Sources/Org2WorkspaceCore/OrgDocumentView.swift
+++ b/apps/macos/Org2Workspace/Sources/Org2WorkspaceCore/OrgDocumentView.swift
@@ -870,15 +870,8 @@ enum RenderedRowChrome {
 }
 
 enum RenderedBlockEditingPolicy {
-  static func startsEditingOnSingleClick(block: OrgEditableBlock, isSourceEditable: Bool) -> Bool {
-    guard isSourceEditable, block.isEditable else { return false }
-    guard OrgCrypt.armorSummary(block.rawText) == nil else { return false }
-    switch block.rendered {
-    case .blank:
-      return false
-    case .heading, .horizontalRule, .keyword, .listItem, .paragraph, .planning, .properties, .quote, .source, .table:
-      return true
-    }
+  static func startsEditingOnSingleClick(block _: OrgEditableBlock, isSourceEditable _: Bool) -> Bool {
+    false
   }
 }
 
@@ -984,14 +977,9 @@ private struct EditableRenderedBlockView<Content: View>: View {
     if usesRowTapGestures {
       content
         .contentShape(Rectangle())
-        .onTapGesture(count: 1) {
+        .onTapGesture {
           actions.select()
-          if startsEditingOnSingleClick {
-            actions.beginEditing()
-          }
-        }
-        .onTapGesture(count: 2) {
-          if block.isEditable {
+          if RenderedBlockEditingPolicy.startsEditingOnSingleClick(block: block, isSourceEditable: isSourceEditable) {
             actions.beginEditing()
           }
         }
@@ -1158,10 +1146,6 @@ private struct EditableRenderedBlockView<Content: View>: View {
     }
     .fixedSize()
     .frame(width: RenderedRowChrome.controlsReserveWidth, alignment: .trailing)
-  }
-
-  private var startsEditingOnSingleClick: Bool {
-    RenderedBlockEditingPolicy.startsEditingOnSingleClick(block: block, isSourceEditable: isSourceEditable)
   }
 
   private var usesRowTapGestures: Bool {

--- a/apps/macos/Org2Workspace/Tests/Org2WorkspaceCoreTests/Org2ModelsTests.swift
+++ b/apps/macos/Org2Workspace/Tests/Org2WorkspaceCoreTests/Org2ModelsTests.swift
@@ -1778,6 +1778,41 @@ final class Org2ModelsTests: XCTestCase {
     XCTAssertFalse(OpenClawComposerKeyCommand.isNewlineCommand(keyCode: 36, modifiers: [.command, .shift]))
   }
 
+  func testOpenClawComposerDraftSyncMergesExternalDraftChangesWithoutDroppingLocalTyping() {
+    XCTAssertEqual(
+      OpenClawComposerDraftSync.localDraftAfterStoreChange(
+        localDraft: "old",
+        previousStoreDraft: "old",
+        nextStoreDraft: "external"
+      ),
+      "external"
+    )
+    XCTAssertEqual(
+      OpenClawComposerDraftSync.localDraftAfterStoreChange(
+        localDraft: "local edit",
+        previousStoreDraft: "",
+        nextStoreDraft: "Use selected entry as context.\n\n"
+      ),
+      "Use selected entry as context.\n\nlocal edit"
+    )
+    XCTAssertEqual(
+      OpenClawComposerDraftSync.localDraftAfterStoreChange(
+        localDraft: "draft plus local edit",
+        previousStoreDraft: "draft",
+        nextStoreDraft: "Use selected entry as context.\n\ndraft"
+      ),
+      "Use selected entry as context.\n\ndraft plus local edit"
+    )
+    XCTAssertEqual(
+      OpenClawComposerDraftSync.localDraftAfterStoreChange(
+        localDraft: "local edit",
+        previousStoreDraft: "",
+        nextStoreDraft: ""
+      ),
+      ""
+    )
+  }
+
   func testOpenClawVoiceDictationAppendsToDraftBeforeSend() {
     XCTAssertEqual(
       WorkspaceStore.openClawDraftByAppendingDictation(existing: "Existing instruction", dictatedText: "Dictated note"),
@@ -5683,7 +5718,7 @@ final class Org2ModelsTests: XCTestCase {
     )
   }
 
-  func testRenderedBlockEditingPolicyStartsInlineEditingForRichBlocks() {
+  func testRenderedBlockEditingPolicyDoesNotStartInlineEditingForRichBlocksOnSingleClick() {
     let editableBlocks = [
       OrgEditableBlock(
         id: "heading",
@@ -5719,7 +5754,7 @@ final class Org2ModelsTests: XCTestCase {
     ]
 
     for block in editableBlocks {
-      XCTAssertTrue(
+      XCTAssertFalse(
         RenderedBlockEditingPolicy.startsEditingOnSingleClick(block: block, isSourceEditable: true),
         block.id
       )
@@ -5730,7 +5765,7 @@ final class Org2ModelsTests: XCTestCase {
     }
   }
 
-  func testRenderedBlockEditingPolicyStartsInlineEditingForStructuralBlocks() {
+  func testRenderedBlockEditingPolicyDoesNotStartInlineEditingForStructuralBlocksOnSingleClick() {
     let divider = OrgEditableBlock(
       id: "divider",
       startLine: 1,
@@ -5745,7 +5780,7 @@ final class Org2ModelsTests: XCTestCase {
       rawText: "",
       rendered: .blank
     )
-    XCTAssertTrue(RenderedBlockEditingPolicy.startsEditingOnSingleClick(block: divider, isSourceEditable: true))
+    XCTAssertFalse(RenderedBlockEditingPolicy.startsEditingOnSingleClick(block: divider, isSourceEditable: true))
     XCTAssertFalse(RenderedBlockEditingPolicy.startsEditingOnSingleClick(block: blank, isSourceEditable: true))
     let properties = OrgEditableBlock(
       id: "properties",
@@ -5754,10 +5789,10 @@ final class Org2ModelsTests: XCTestCase {
       rawText: ":PROPERTIES:\n:Owner: Avi\n:END:",
       rendered: .properties([OrgPropertyRow(key: "Owner", value: "Avi")])
     )
-    XCTAssertTrue(RenderedBlockEditingPolicy.startsEditingOnSingleClick(block: properties, isSourceEditable: true))
+    XCTAssertFalse(RenderedBlockEditingPolicy.startsEditingOnSingleClick(block: properties, isSourceEditable: true))
   }
 
-  func testRenderedBlockEditingPolicyStartsInlineEditingForMediaParagraphs() throws {
+  func testRenderedBlockEditingPolicyDoesNotStartInlineEditingForMediaParagraphsOnSingleClick() throws {
     let embedded = try XCTUnwrap(OrgEntryRenderer.parseEditable(
       "inline images [[file:images/image.png][Image]]"
     ).first)
@@ -5765,8 +5800,8 @@ final class Org2ModelsTests: XCTestCase {
       "[[file:images/image.png][Image]]"
     ).first)
 
-    XCTAssertTrue(RenderedBlockEditingPolicy.startsEditingOnSingleClick(block: embedded, isSourceEditable: true))
-    XCTAssertTrue(RenderedBlockEditingPolicy.startsEditingOnSingleClick(block: standalone, isSourceEditable: true))
+    XCTAssertFalse(RenderedBlockEditingPolicy.startsEditingOnSingleClick(block: embedded, isSourceEditable: true))
+    XCTAssertFalse(RenderedBlockEditingPolicy.startsEditingOnSingleClick(block: standalone, isSourceEditable: true))
   }
 
   func testRenderedBlockDisplayPolicyCollapsesBlankButKeepsProperties() {


### PR DESCRIPTION
## Summary
- add scheduled TODO capture options to the iOS new-note flow
- add an iOS Share extension named Capture to Org2 backed by shared corpus bookmark access
- include macOS workspace fixes for OpenClaw draft merging and rendered-block single-click behavior

## Validation
- xcodebuild -project apps/ios/Org2Mobile/Org2Mobile.xcodeproj -scheme Org2Mobile -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build
- swift test --package-path apps/macos/Org2Workspace