### PR TITLE
Unify docs syntax highlighting

### DIFF
--- a/docs/site/assets/shiki-vscode.js
+++ b/docs/site/assets/shiki-vscode.js
@@ -3,6 +3,27 @@ import { createHighlighter } from 'https://esm.sh/shiki@1.29.1';
 const THEME_LIGHT = 'github-light';
 const THEME_DARK = 'github-dark';
 
+const ORG2_LANGUAGE = {
+  name: 'org2',
+  scopeName: 'source.org2',
+  patterns: [
+    { name: 'comment.line.number-sign.org2', match: '^\\s*#(?!\\+).*?$' },
+    { name: 'keyword.control.block.org2', match: '^\\s*```.*$' },
+    { name: 'keyword.control.block.org2', match: '^\\s*#\\+(?:begin|end)_[A-Za-z0-9_-]+\\b.*$' },
+    { name: 'markup.heading.org2', match: '^\\*+(?=\\s)' },
+    { name: 'keyword.control.todo.org2', match: '\\b(?:TODO|IN_PROGRESS|DONE|CANCELLED|CANCELED|WAITING|BLOCKED|NEXT)\\b' },
+    { name: 'keyword.other.planning.org2', match: '^\\s*(?:SCHEDULED|DEADLINE|CLOSED):' },
+    { name: 'keyword.other.directive.org2', match: '^\\s*#\\+[A-Za-z][A-Za-z0-9_-]*(?=:)' },
+    { name: 'entity.name.section.drawer.org2', match: '^\\s*:(?:PROPERTIES|LOGBOOK|END):\\s*$' },
+    { name: 'variable.other.property.org2', match: '^\\s*:[A-Za-z][A-Za-z0-9_-]*:(?=\\s)' },
+    { name: 'constant.language.priority.org2', match: '\\[#[A-Z]\\]' },
+    { name: 'constant.other.timestamp.org2', match: '(?:<|\\[)\\d{4}-\\d{2}-\\d{2}[^>\\]]*(?:>|\\])' },
+    { name: 'string.other.link.org2', match: '\\[\\[[^\\]]+\\](?:\\[[^\\]]*\\])?\\]' },
+    { name: 'entity.name.tag.org2', match: ':[A-Za-z0-9_@#%]+(?::[A-Za-z0-9_@#%]+)*:\\s*$' },
+    { name: 'markup.list.org2', match: '^\\s*(?:[-+] |\\d+[.)] )' }
+  ]
+};
+
 function prefersDark() {
   return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
 }
@@ -16,8 +37,7 @@ function languageFromCodeEl(codeEl) {
   if (raw === 'ts') return 'typescript';
   if (raw === 'sh' || raw === 'shell') return 'bash';
   if (raw === 'yml') return 'yaml';
-  // org/org2 grammar is not bundled in Shiki by default; fall back to text.
-  if (raw === 'org' || raw === 'org2') return 'text';
+  if (raw === 'org' || raw === 'org2') return 'org2';
   return raw;
 }
 
@@ -28,17 +48,16 @@ function activeTheme() {
 async function run() {
   const highlighter = await createHighlighter({
     themes: [THEME_LIGHT, THEME_DARK],
-    langs: ['text', 'bash', 'json', 'javascript', 'typescript', 'tsx', 'yaml', 'html', 'css', 'markdown', 'sql', 'haskell', 'java', 'c', 'cpp', 'csharp', 'ruby', 'php', 'kotlin', 'swift', 'scala', 'lua', 'go', 'rust', 'python']
+    langs: ['text', 'bash', 'json', 'javascript', 'typescript', 'tsx', 'yaml', 'html', 'css', 'markdown', 'sql', 'haskell', 'java', 'c', 'cpp', 'csharp', 'ruby', 'php', 'kotlin', 'swift', 'scala', 'lua', 'go', 'rust', 'python', ORG2_LANGUAGE]
   });
 
   const theme = activeTheme();
 
-  // Block code: pre > code
-  for (const pre of document.querySelectorAll('pre.org2-src')) {
+  // Block code: source blocks and standalone renderer directives.
+  for (const pre of document.querySelectorAll('pre.org2-src, pre.org2-directive')) {
     const codeEl = pre.querySelector('code');
-    if (!codeEl) continue;
-    const code = codeEl.textContent || '';
-    const lang = languageFromCodeEl(codeEl);
+    const code = (codeEl || pre).textContent || '';
+    const lang = pre.classList.contains('org2-directive') ? 'org2' : languageFromCodeEl(codeEl || pre);
     const html = highlighter.codeToHtml(code, { lang, theme });
     const wrapper = document.createElement('div');
     wrapper.innerHTML = html;

--- a/docs/site/features.org
+++ b/docs/site/features.org
@@ -36,7 +36,7 @@
       </ul>
       <div class="org2-command" aria-label="Planning and graph commands">
         <span>Planning and graph commands</span>
-        <pre><code>org2 agenda --dir ~/notes --recursive --tui
+        <pre class="org2-src language-sh"><code class="language-sh">org2 agenda --dir ~/notes --recursive --tui
 org2 roam graph --dir ~/notes --recursive --format report</code></pre>
       </div>
       <p class="org2-feature-links"><a href="workflows.html">Everyday workflows</a><a href="tooling-reference.html">CLI reference</a></p>
@@ -58,7 +58,7 @@ org2 roam graph --dir ~/notes --recursive --format report</code></pre>
       </ul>
       <div class="org2-command" aria-label="Agent context and review commands">
         <span>Context and review commands</span>
-        <pre><code>org2 agent context --query "launch risks" --dir ~/notes --recursive
+        <pre class="org2-src language-sh"><code class="language-sh">org2 agent context --query "launch risks" --dir ~/notes --recursive
 org2 review list --status pending --dir ~/notes</code></pre>
       </div>
       <p class="org2-feature-links"><a href="agent-quickstart.html">Agent quickstart</a><a href="openclaw-knowledge-layer.html">OpenClaw integration</a></p>
@@ -79,7 +79,7 @@ org2 review list --status pending --dir ~/notes</code></pre>
       </ul>
       <div class="org2-command" aria-label="Data notebook commands">
         <span>Inspect or materialize a result</span>
-        <pre><code>org2 query-data --file notes/readiness.org2 --inspect
+        <pre class="org2-src language-sh"><code class="language-sh">org2 query-data --file notes/readiness.org2 --inspect
 org2 query-data --file notes/readiness.org2 --results weekly --apply</code></pre>
       </div>
       <p class="org2-feature-links"><a href="language-reference.html#local-datasets-and-sql-views">Notebook syntax</a><a href="tooling-reference.html">Query-data options</a></p>
@@ -117,7 +117,7 @@ org2 query-data --file notes/readiness.org2 --results weekly --apply</code></pre
         <article><strong>Publishing</strong><p>Export one file or publish a recursive project with navigation, styles, rewritten links, and generated indexes. This documentation site is built by Org2.</p></article>
         <div class="org2-command" aria-label="Formatting and publishing commands">
           <span>Check formatting or preview a site</span>
-          <pre><code>org2 fmt --dir ~/notes --recursive --check
+          <pre class="org2-src language-sh"><code class="language-sh">org2 fmt --dir ~/notes --recursive --check
 org2 publish docs-site --config org2.json --preview</code></pre>
         </div>
       </div>

--- a/site/assets/shiki-vscode.js
+++ b/site/assets/shiki-vscode.js
@@ -3,6 +3,27 @@ import { createHighlighter } from 'https://esm.sh/shiki@1.29.1';
 const THEME_LIGHT = 'github-light';
 const THEME_DARK = 'github-dark';
 
+const ORG2_LANGUAGE = {
+  name: 'org2',
+  scopeName: 'source.org2',
+  patterns: [
+    { name: 'comment.line.number-sign.org2', match: '^\\s*#(?!\\+).*?$' },
+    { name: 'keyword.control.block.org2', match: '^\\s*```.*$' },
+    { name: 'keyword.control.block.org2', match: '^\\s*#\\+(?:begin|end)_[A-Za-z0-9_-]+\\b.*$' },
+    { name: 'markup.heading.org2', match: '^\\*+(?=\\s)' },
+    { name: 'keyword.control.todo.org2', match: '\\b(?:TODO|IN_PROGRESS|DONE|CANCELLED|CANCELED|WAITING|BLOCKED|NEXT)\\b' },
+    { name: 'keyword.other.planning.org2', match: '^\\s*(?:SCHEDULED|DEADLINE|CLOSED):' },
+    { name: 'keyword.other.directive.org2', match: '^\\s*#\\+[A-Za-z][A-Za-z0-9_-]*(?=:)' },
+    { name: 'entity.name.section.drawer.org2', match: '^\\s*:(?:PROPERTIES|LOGBOOK|END):\\s*$' },
+    { name: 'variable.other.property.org2', match: '^\\s*:[A-Za-z][A-Za-z0-9_-]*:(?=\\s)' },
+    { name: 'constant.language.priority.org2', match: '\\[#[A-Z]\\]' },
+    { name: 'constant.other.timestamp.org2', match: '(?:<|\\[)\\d{4}-\\d{2}-\\d{2}[^>\\]]*(?:>|\\])' },
+    { name: 'string.other.link.org2', match: '\\[\\[[^\\]]+\\](?:\\[[^\\]]*\\])?\\]' },
+    { name: 'entity.name.tag.org2', match: ':[A-Za-z0-9_@#%]+(?::[A-Za-z0-9_@#%]+)*:\\s*$' },
+    { name: 'markup.list.org2', match: '^\\s*(?:[-+] |\\d+[.)] )' }
+  ]
+};
+
 function prefersDark() {
   return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
 }
@@ -16,8 +37,7 @@ function languageFromCodeEl(codeEl) {
   if (raw === 'ts') return 'typescript';
   if (raw === 'sh' || raw === 'shell') return 'bash';
   if (raw === 'yml') return 'yaml';
-  // org/org2 grammar is not bundled in Shiki by default; fall back to text.
-  if (raw === 'org' || raw === 'org2') return 'text';
+  if (raw === 'org' || raw === 'org2') return 'org2';
   return raw;
 }
 
@@ -28,17 +48,16 @@ function activeTheme() {
 async function run() {
   const highlighter = await createHighlighter({
     themes: [THEME_LIGHT, THEME_DARK],
-    langs: ['text', 'bash', 'json', 'javascript', 'typescript', 'tsx', 'yaml', 'html', 'css', 'markdown', 'sql', 'haskell', 'java', 'c', 'cpp', 'csharp', 'ruby', 'php', 'kotlin', 'swift', 'scala', 'lua', 'go', 'rust', 'python']
+    langs: ['text', 'bash', 'json', 'javascript', 'typescript', 'tsx', 'yaml', 'html', 'css', 'markdown', 'sql', 'haskell', 'java', 'c', 'cpp', 'csharp', 'ruby', 'php', 'kotlin', 'swift', 'scala', 'lua', 'go', 'rust', 'python', ORG2_LANGUAGE]
   });
 
   const theme = activeTheme();
 
-  // Block code: pre > code
-  for (const pre of document.querySelectorAll('pre.org2-src')) {
+  // Block code: source blocks and standalone renderer directives.
+  for (const pre of document.querySelectorAll('pre.org2-src, pre.org2-directive')) {
     const codeEl = pre.querySelector('code');
-    if (!codeEl) continue;
-    const code = codeEl.textContent || '';
-    const lang = languageFromCodeEl(codeEl);
+    const code = (codeEl || pre).textContent || '';
+    const lang = pre.classList.contains('org2-directive') ? 'org2' : languageFromCodeEl(codeEl || pre);
     const html = highlighter.codeToHtml(code, { lang, theme });
     const wrapper = document.createElement('div');
     wrapper.innerHTML = html;

--- a/site/features.html
+++ b/site/features.html
@@ -88,7 +88,7 @@ a { text-decoration-thickness: 0.08em; text-underline-offset: 0.15em; }
       </ul>
       <div class="org2-command" aria-label="Planning and graph commands">
         <span>Planning and graph commands</span>
-        <pre><code>org2 agenda --dir ~/notes --recursive --tui
+        <pre class="org2-src language-sh"><code class="language-sh">org2 agenda --dir ~/notes --recursive --tui
 org2 roam graph --dir ~/notes --recursive --format report</code></pre>
       </div>
       <p class="org2-feature-links"><a href="workflows.html">Everyday workflows</a><a href="tooling-reference.html">CLI reference</a></p>
@@ -110,7 +110,7 @@ org2 roam graph --dir ~/notes --recursive --format report</code></pre>
       </ul>
       <div class="org2-command" aria-label="Agent context and review commands">
         <span>Context and review commands</span>
-        <pre><code>org2 agent context --query "launch risks" --dir ~/notes --recursive
+        <pre class="org2-src language-sh"><code class="language-sh">org2 agent context --query "launch risks" --dir ~/notes --recursive
 org2 review list --status pending --dir ~/notes</code></pre>
       </div>
       <p class="org2-feature-links"><a href="agent-quickstart.html">Agent quickstart</a><a href="openclaw-knowledge-layer.html">OpenClaw integration</a></p>
@@ -131,7 +131,7 @@ org2 review list --status pending --dir ~/notes</code></pre>
       </ul>
       <div class="org2-command" aria-label="Data notebook commands">
         <span>Inspect or materialize a result</span>
-        <pre><code>org2 query-data --file notes/readiness.org2 --inspect
+        <pre class="org2-src language-sh"><code class="language-sh">org2 query-data --file notes/readiness.org2 --inspect
 org2 query-data --file notes/readiness.org2 --results weekly --apply</code></pre>
       </div>
       <p class="org2-feature-links"><a href="language-reference.html#local-datasets-and-sql-views">Notebook syntax</a><a href="tooling-reference.html">Query-data options</a></p>
@@ -169,7 +169,7 @@ org2 query-data --file notes/readiness.org2 --results weekly --apply</code></pre
         <article><strong>Publishing</strong><p>Export one file or publish a recursive project with navigation, styles, rewritten links, and generated indexes. This documentation site is built by Org2.</p></article>
         <div class="org2-command" aria-label="Formatting and publishing commands">
           <span>Check formatting or preview a site</span>
-          <pre><code>org2 fmt --dir ~/notes --recursive --check
+          <pre class="org2-src language-sh"><code class="language-sh">org2 fmt --dir ~/notes --recursive --check
 org2 publish docs-site --config org2.json --preview</code></pre>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- add an Org2-specific Shiki grammar for headings, TODO states, planning metadata, properties, links, tags, and directives
- opt the feature-page CLI examples into the same Bash highlighting used elsewhere
- highlight standalone renderer directives instead of leaving isolated code-like blocks plain

## Root cause

The site highlighter deliberately mapped Org and Org2 blocks to plain text, while several hand-authored feature examples lacked the language classes used to discover highlighted blocks.

## Verification

- visually checked Org2 examples on `language-reference.html`
- visually checked Bash command cards on `features.html`
- `node --check docs/site/assets/shiki-vscode.js`
- `npm run docs:check`
- `npm run check:generated`

## Documentation

This changes the docs site's presentation only. Canonical site sources and generated assets are updated together; no product semantics or user-facing prose changed.
