### PR TITLE
Fix indented property drawer parsing

### DIFF
--- a/docs/site/language-reference.org
+++ b/docs/site/language-reference.org
@@ -66,6 +66,7 @@ Example:
 ** Property drawers
 
 - Drawer delimiters: =:PROPERTIES:= ... =:END:=
+- Consistently space-indented property drawers are accepted for legacy files. =org2 fmt= canonicalizes their delimiter and property lines to column zero.
 - Common keys used by Org2 workflows:
   - =:ID:=
   - =:CUSTOM_ID:=

--- a/site/language-reference.html
+++ b/site/language-reference.html
@@ -119,6 +119,7 @@ a { text-decoration-thickness: 0.08em; text-underline-offset: 0.15em; }
 <h2 id="property-drawers">Property drawers</h2>
 <ul>
 <li><p>Drawer delimiters: <code>:PROPERTIES:</code> ... <code>:END:</code></p></li>
+<li><p>Consistently space-indented property drawers are accepted for legacy files. <code>org2 fmt</code> canonicalizes their delimiter and property lines to column zero.</p></li>
 <li>
 <p>Common keys used by Org2 workflows:</p>
 <ul>

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -616,31 +616,44 @@ type ParseDrawerResult = {
 
 function parsePropertyDrawer(lines: string[], startLineIndex: number): ParsePropertyDrawerResult {
   const startLineNumber = startLineIndex + 1;
+  const start = lines[startLineIndex] ?? "";
+  const startMatch = /^(\s*):PROPERTIES:$/.exec(start);
 
-  if (lines[startLineIndex] !== ":PROPERTIES:") {
+  if (!startMatch) {
     fail(makeError("Invalid property drawer; expected :PROPERTIES:", startLineNumber, 1));
+  }
+
+  const indent = startMatch[1] ?? "";
+  if (indent.includes("\t")) {
+    fail(makeError("Unsupported construct: tab character", startLineNumber, start.indexOf("\t") + 1));
   }
 
   const properties: PropertyDrawerNode["properties"] = [];
 
   for (let i = startLineIndex + 1; i < lines.length; i += 1) {
     const lineNumber = i + 1;
-    const line = lines[i];
+    const sourceLine = lines[i] ?? "";
 
-    if (line === ":END:") {
+    if (sourceLine === `${indent}:END:`) {
       return {
         drawer: { type: "PropertyDrawer", properties },
         nextLineIndex: i + 1,
       };
     }
 
+    if (!sourceLine.startsWith(indent)) {
+      fail(makeError("Invalid property drawer line; expected matching indentation", lineNumber, 1));
+    }
+
+    const line = sourceLine.slice(indent.length);
+
     if (isBlank(line)) {
-      fail(makeError("Invalid property drawer; blank lines are not allowed", lineNumber, 1));
+      fail(makeError("Invalid property drawer; blank lines are not allowed", lineNumber, indent.length + 1));
     }
 
     const match = /^:([^:\s]+):(\s*)(.*)$/.exec(line);
     if (!match) {
-      fail(makeError("Invalid property drawer line; expected :KEY: VALUE", lineNumber, 1));
+      fail(makeError("Invalid property drawer line; expected :KEY: VALUE", lineNumber, indent.length + 1));
     }
 
     const key = match[1];
@@ -648,7 +661,7 @@ function parsePropertyDrawer(lines: string[], startLineIndex: number): ParseProp
     const rawValue = match[3];
 
     if (ws.includes("\t")) {
-      fail(makeError("Unsupported construct: tab character", lineNumber, key.length + 3));
+      fail(makeError("Unsupported construct: tab character", lineNumber, indent.length + key.length + 3));
     }
 
     properties.push({ key, value: rawValue });
@@ -1247,7 +1260,7 @@ export function parseOrgToCanonicalAst(input: string, options: ParseOptions = {}
       continue;
     }
 
-    if (line === ":PROPERTIES:") {
+    if (/^\s*:PROPERTIES:$/.test(line)) {
       flushParagraph();
       endList();
       flushAffiliatedKeywords();

--- a/test/test-app-html-render.mjs
+++ b/test/test-app-html-render.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { renderOrgCharts } from "../dist/chartRender.js";
 import { renderOrgDocumentToAppHtml, renderOrgDocumentToHtml } from "../dist/export.js";
 import { parseOrgToCanonicalAst } from "../dist/parser.js";
+import { printCanonicalAstToOrg } from "../dist/printer.js";
 
 const source = `#+TITLE: App rendering
 #+HTML_HEAD: <script>globalThis.documentHeadRan = true</script>
@@ -85,6 +86,63 @@ assert.doesNotMatch(published.html, /org2-table-scroll/);
 assert.doesNotMatch(published.html, /org2-app-document-script/);
 assert.match(published.html, /<section class="org2-headline level-1"/);
 assert.match(published.html, /<dl class="org2-properties">/);
+
+const indentedDrawerSource = `* Section
+** Slide one
+*** Column
+    :PROPERTIES:
+    :BEAMER_COL: 0.45
+    :BEAMER_ENV: block
+    :END:
+    Column body.
+** Slide two
+Sibling body.
+`;
+const indentedDrawerDocument = parseOrgToCanonicalAst(indentedDrawerSource, { sourceRanges: true });
+const section = indentedDrawerDocument.children.find((node) => node.type === "Headline");
+assert.ok(section && section.type === "Headline");
+const slideOne = section.children.find((node) =>
+  node.type === "Headline" && node.title.some((inline) => inline.type === "Text" && inline.value === "Slide one")
+);
+assert.ok(slideOne && slideOne.type === "Headline");
+const column = slideOne.children.find((node) =>
+  node.type === "Headline" && node.title.some((inline) => inline.type === "Text" && inline.value === "Column")
+);
+assert.ok(column && column.type === "Headline");
+assert.equal(column.children[0]?.type, "PropertyDrawer");
+assert.ok(section.children.some((node) =>
+  node.type === "Headline" && node.title.some((inline) => inline.type === "Text" && inline.value === "Slide two")
+), "a sibling heading after an indented property drawer must remain outside the drawer");
+
+const indentedDrawerRendered = renderOrgDocumentToAppHtml(indentedDrawerDocument);
+assert.match(indentedDrawerRendered.html, /<details class="org2-properties-drawer" open/);
+assert.match(indentedDrawerRendered.html, /<h2[^>]*>Slide two<\/h2>/);
+assert.match(indentedDrawerRendered.html, /Sibling body\./);
+assert.doesNotMatch(indentedDrawerRendered.html, /<details class="org2-drawer"><summary>PROPERTIES<\/summary>/);
+
+const canonicalizedDrawer = printCanonicalAstToOrg(indentedDrawerDocument);
+assert.match(canonicalizedDrawer, /\*\*\* Column\n:PROPERTIES:\n:BEAMER_COL: 0\.45\n:BEAMER_ENV: block\n:END:/);
+assert.doesNotMatch(canonicalizedDrawer, /^ +:PROPERTIES:$/m);
+const reparsedCanonicalDrawer = parseOrgToCanonicalAst(canonicalizedDrawer);
+assert.ok(reparsedCanonicalDrawer.children.some((node) =>
+  node.type === "Headline"
+  && node.children.some((child) =>
+    child.type === "Headline"
+    && child.title.some((inline) => inline.type === "Text" && inline.value === "Slide two")
+  )
+));
+assert.throws(
+  () => parseOrgToCanonicalAst(`* Section
+** Slide one
+    :PROPERTIES:
+    :BEAMER_ENV: block
+:END:
+** Slide two
+Sibling body.
+`),
+  /Invalid property drawer line; expected matching indentation/,
+  "a mismatched indented property drawer must fail instead of consuming following headings",
+);
 
 const fileMetadataSource = `#+title: Machine report
 #+id: report-id


### PR DESCRIPTION
## What changed

- Parse consistently space-indented PROPERTIES drawers as first-class property drawers.
- Require the closing delimiter and property lines to use matching indentation, so malformed drawers fail instead of absorbing following headings.
- Canonicalize accepted legacy indentation to column-zero drawer syntax through org2 fmt.
- Add app-render/export regression coverage and update the language reference plus generated site page.

## Why

Indented property drawers were routed through the generic drawer parser. A mismatched or unrecognized terminator could therefore consume the rest of the document, hiding later slides and headings in the shared export path used by the macOS app.

## User impact

Legacy indented property drawers render with normal property semantics, following sibling headings remain visible, and malformed indentation produces an actionable parse error rather than silent document loss.

## Validation

- npm test
- npm run docs:check
- npm run check:generated
- git diff --check